### PR TITLE
Fixed warning messages

### DIFF
--- a/output/stationProcessor.f90
+++ b/output/stationProcessor.f90
@@ -217,12 +217,12 @@ do f=1, dataFileNames%n
    call determineNetCDFFileCharacteristics(sf(f), m, n)
    ! check to see if data are available for the full requested time range
    if ( (timesecStart.gt.0).and.(timesecStart.gt. sf(f)%timesec(sf(f)%nSnaps) ) ) then
-      write(scratchMessage,'("The data file ends at time t=",e17.8," (s) but the requested start time is t=",e17.8," (s).")') timesecStart, sf(f)%timesec(sf(f)%nSnaps)  
+      write(scratchMessage,'("The data file ends at time t=",e17.8," (s) but the requested start time is t=",e17.8," (s).")') sf(f)%timesec(sf(f)%nSnaps), timesecStart  
       call allMessage(INFO,scratchMessage)
       outOfRange(f) = .true.
    endif
    if ( (timesecEnd.gt.0).and.(timesecEnd.lt.sf(f)%timesec(1)) ) then
-      write(scratchMessage,'("The data file starts at time t=",e17.8," (s) but the requested end time is t=",e17.8," (s).")') , timesecEnd, sf(f)%timesec(1)
+      write(scratchMessage,'("The data file starts at time t=",e17.8," (s) but the requested end time is t=",e17.8," (s).")') , sf(f)%timesec(1), timesecEnd
       call allMessage(WARNING,scratchMessage)
       outOfRange(f) = .true.
    endif

--- a/output/stationProcessor.f90
+++ b/output/stationProcessor.f90
@@ -218,7 +218,7 @@ do f=1, dataFileNames%n
    ! check to see if data are available for the full requested time range
    if ( (timesecStart.gt.0).and.(timesecStart.gt. sf(f)%timesec(sf(f)%nSnaps) ) ) then
       write(scratchMessage,'("The data file ends at time t=",e17.8," (s) but the requested start time is t=",e17.8," (s).")') sf(f)%timesec(sf(f)%nSnaps), timesecStart  
-      call allMessage(INFO,scratchMessage)
+      call allMessage(WARNING,scratchMessage)
       outOfRange(f) = .true.
    endif
    if ( (timesecEnd.gt.0).and.(timesecEnd.lt.sf(f)%timesec(1)) ) then


### PR DESCRIPTION
Two warning messages wrote out values in the wrong order, making the messages incorrect and confusing.  Note also there's an errant comma in the 2nd write command that was updated.  I don't understand why it's there, but am not touching it.