### PR TITLE
Added patch and README for fixing perlbrew on Stampede2

### DIFF
--- a/PERL/README-perlbrew-patch.txt
+++ b/PERL/README-perlbrew-patch.txt
@@ -1,0 +1,21 @@
+Recent versions of perlbrew cause fatal
+errors on Lustre systems like that on
+Stampede2. The fix is to apply the included
+patch.
+
+1. install perlbrew, but before you install any versions of
+perl,
+
+2. run this command from the same directory as the patch:
+
+	cp patchperl.patch ~/perl5 && cd ~/perl5 && patch -p 1 < ./patchperl.patch
+
+3. install the recommended version of perl using perlbrew:
+
+Assuming the patch got applied correctly, you should be able to
+build perl. Recent experience has also shown that 1 test fails
+during the final phases of the build install, and this causes
+the entire install to be aborted. It is fine to build perl
+without tests if this happens:
+
+	perlbrew --notest install perl-5.28.2

--- a/PERL/patchperl.patch
+++ b/PERL/patchperl.patch
@@ -1,0 +1,24 @@
+--- a/perlbrew/bin/patchperl
++++ b/perlbrew/bin/patchperl
+@@ -534,13 +534,22 @@ $fatpacked{"Devel/PatchPerl.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<
+   sub _patch
+   {
+     my($patch) = @_;
+-    print "patching $_\n" for $patch =~ /^\+{3}\s+(\S+)/gm;
++    my @ro = ();
++    for ($patch =~ /^\+{3}\s+(\S+)/gm) {
++      print "patching $_\n";
++      if (-r $_ and not -w $_) {
++        push @ro, $_;
++        chmod 0644, $_;
++      }
++    }
+     my $diff = 'tmp.diff';
+     _write_or_die($diff, $patch);
+     die "No patch utility found\n" unless $patch_exe;
+     local $ENV{PATCH_GET} = 0; # I can't reproduce this at all, but meh.
+     _run_or_die("$patch_exe -f -s -p0 <$diff");
+     unlink $diff or die "unlink $diff: $!\n";
++    # put back ro to 0444
++    chmod 0444, @ro;
+   }


### PR DESCRIPTION
The root issue is that Lustre treats a write to a write protected
file as fatal and kills the entire process.