### PR TITLE
Added AWS integration tool for sending email via SES.

### DIFF
--- a/PERL-MODULES
+++ b/PERL-MODULES
@@ -9,3 +9,8 @@ Math::Trig
 Net::FTP
 Params::Validate
 Time::Local
+Email::Sender::Simple
+Email::Sender::Transport::SMTP::TLS
+Email::Simple::Creator
+Config::Tiny
+Try::Tiny

--- a/README-perlbrew.txt
+++ b/README-perlbrew.txt
@@ -13,6 +13,14 @@ I. Installing perlbrew and your desired version(s) of perl
 
 0. Login to the head node of the computing system where you'll be installing perlbrew
 
+NOTE: Experience has shown that when logging into a head node of an HPC resource, you may be
+placed on one of multiple machines. And while they have access to the same file system, the environment
+may be set up slightly differently on each head node. This means that one must take care to note
+the head node on which they have set up perlbrew - future logins may land them on head nodes that
+are not quite set up. So if you login to a head node and it's not set up right, it could be that
+you're on a different one that before. This also affects screen sessions, since the screen session
+on one machine will not be accessible on a different machine.
+
 1. Install perlbrew
 
   curl -L https://install.perlbrew.pl | bash
@@ -47,6 +55,8 @@ install as many versions of perl as you whish using this method. perl 5.28.2 is 
 of perl at the time of this writing.
 
   perlbrew install perl-5.28.2
+
+  Note: if the build fails, see the Troubleshooting (Append. A) below.
 
 4. Set this perl to be your default perl, overriding the system perl on all interactive and batch
 terminal sessions; when ~/perl5/perlbrew/etc/bashrc is source'd on login or new shell, it will automatically
@@ -97,6 +107,9 @@ Make sure the perl you're expecting is first in the PATH:
 
   cpanm Perl::Tidy
   which perltidy      # should point to the version of perltidy installed by cpanm
+
+  # make sure you're in the asgs scripts directory, then copy the tidy file to $HOME as follows:
+
   cp PERL/perltidyrc ~/.perltidyrc # ASGS standard perltidy options
 
   The use of perltidy is outside the scope of this README, but a quick start for anyone using vim is as follows.
@@ -149,3 +162,27 @@ IV.  Autmating this process
 in the ASGS repository under the file, "cloud/general/init-perlbrew.sh".
      
 Have fun!
+
+Appendix A - Troubleshooting
+
+Case 1: Build fails
+
+1. view the log as suggested in the error output
+2. determine the cause of the error, some of the failure types are:
+
+* unit test failure (more common than others)
+* compiler error (super rare)
+* configure phase error (rare)
+
+In the case of the unit test failure, take note of the tests that failed (end in .t) and how many tests failed. If it's
+a very small amount of tests then it's usually safe to re-run the install using the "--no-test" option.
+
+  perlbrew install --no-test perl-5.28.2
+
+If there are widespread test failures, then this could indicate something environmental at work. A search of the errors seen
+on duck duck go (or G) may also prove useful. But perlbrew is pretty robust, as is the Perl source distribution.
+
+Compiler and configure errors are tougher to diagnose, so they are not covered here since it's more likely than not related
+to a perl or perlbrew issue. These are very rare these days, especially on relatively common platforms like Linux or some Unix
+variant.
+

--- a/README-setup-email.txt
+++ b/README-setup-email.txt
@@ -1,0 +1,18 @@
+This document will be expanded, but the necessary step is to
+create a file in $HOME called $HOME/asgs-global.conf that
+contains the AWS SES (Simple Email Service) credentials. See
+the asgs-global.conf.sample file in the ASGS repository as
+a template.
+
+NOTE: Lead operator will need to provide you with the required
+SMTP authentication information, which may change time to time.
+
+For help on the tool, 
+
+1. Usage:
+
+  ./asgs-sendmail.pl --help
+
+2. Details
+
+  perldoc asgs-sendmail.pl

--- a/asgs-global.conf.sample
+++ b/asgs-global.conf.sample
@@ -1,0 +1,17 @@
+;;; this file contains information that should NOT 
+;;; be stored in a git repository with live values.
+;;; Live config file should exists as $HOME/asgs-global.conf
+
+[email]
+from_address=info@stormsurge.email
+reply_to_address=info@stormsurge.email
+smtp_host=email-smtp.us-east-1.amazonaws.com
+smtp_port=587
+smtp_username=<get from lead operator>
+smtp_password=<get from lead operator>
+
+;;; note, "from" addresses must be verified via Amazon's SES console
+;;; before deviating from 'info@stormsurge.email' 
+;;; note, from_address is not what it may look like it came from,
+;;; currently it may be slightly different because this part of it
+;;; is actually managed by AWS on their end 

--- a/asgs-sendmail.pl
+++ b/asgs-sendmail.pl
@@ -81,22 +81,22 @@ __END__
 
 =head1 NAME
 
-  asgs_sendmail.pl
+  asgs-sendmail.pl
 
 =head1 USAGE 
 
   # piped STDIN
-  cat body.txt | asgs_sendmail.pl [-c override/default/conf] --subject "subject line" --to recipient@email.tld
-  some-utility | asgs_sendmail.pl [-c override/default/conf] --subject "subject line" --to recipient@email.tld
+  cat body.txt | asgs-sendmail.pl [-c override/default/conf] --subject "subject line" --to recipient@email.tld
+  some-utility | asgs-sendmail.pl [-c override/default/conf] --subject "subject line" --to recipient@email.tld
 
   # directed file contents in using '<', typical unix syntax
-  asgs_sendmail.pl [-c override/default/conf] --subject "subject line" --to recipient@email.tld < body.txt
+  asgs-sendmail.pl [-c override/default/conf] --subject "subject line" --to recipient@email.tld < body.txt
 
 =head2 Multiple Recipients
 
 The C<--to> options accepts a comma delimited list of email addresses:
 
-  some-utility | asgs_sendmail.pl [-c override/default/conf] --subject "subject line" --to "recipient1@email.tld, recipient2@email.tld, ..., recipientN@email.tld"
+  some-utility | asgs-sendmail.pl [-c override/default/conf] --subject "subject line" --to "recipient1@email.tld, recipient2@email.tld, ..., recipientN@email.tld"
 
 =head1 DESCRIPTION
 

--- a/asgs-sendmail.pl
+++ b/asgs-sendmail.pl
@@ -1,0 +1,150 @@
+#!/usr/bin/env perl
+
+package util::asgs_sendmail;
+
+use strict;
+use warnings;
+
+use Email::Sender::Simple qw(sendmail);
+use Email::Sender::Transport::SMTP::TLS;
+use Email::Simple::Creator;
+use Config::Tiny;
+use Try::Tiny;
+use Getopt::Long;
+use constant EXIT_SUCCESS => 0;
+
+my $subject     = q{no subject};
+my $HOME        = ( getpwuid($<) )[7];
+my $config_file = qq{$HOME/asgs-global.conf};
+my $to;
+
+GetOptions(
+    "c|config=s"  => \$config_file,
+    "h|help"      => \&show_help,
+    "s|subject=s" => \$subject,
+    "t|to=s"      => \$to,
+);
+
+# verify recipient email has been set via --to
+die qq{a recipient is required to be defined via --to\n} unless defined $to;
+
+exit run();
+
+sub run {
+    my @content = <STDIN>;
+    my $content;
+    if (@content) {
+        $content = join( qq{\n}, @content );
+    }
+    else {
+        $content = q{empty message};
+    }
+
+    my $config = Config::Tiny->new();
+    $config = Config::Tiny->read($config_file);
+
+    my $transport = Email::Sender::Transport::SMTP::TLS->new(
+        host     => $config->{email}->{smtp_host},
+        port     => $config->{email}->{smtp_port} // 587,    # defaults to TLS if not set
+        username => $config->{email}->{smtp_username},
+        password => $config->{email}->{smtp_password},
+        helo     => 'HELO',
+    );
+
+    my $message = Email::Simple->create(
+        header => [
+            'Reply-To' => $config->{email}->{reply_to_address} // $config->{email}->{from_address},
+            From       => $config->{email}->{from_address},
+            To         => $to,
+            Subject    => qq{[asgs-notification] $subject},
+        ],
+        body => $content,
+    );
+
+    try {
+        sendmail( $message, { transport => $transport } );
+    }
+    catch {
+        die "Error sending email: $_";
+    };
+    return EXIT_SUCCESS;
+}
+
+sub show_help {
+    print qq{$0 --subject "subject line" --to recipient\@email.tdl < body.txt\n};
+    exit EXIT_SUCCESS;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+  asgs_sendmail.pl
+
+=head1 USAGE 
+
+  # piped STDIN
+  cat body.txt | asgs_sendmail.pl [-c override/default/conf] --subject "subject line" --to recipient@email.tld
+  some-utility | asgs_sendmail.pl [-c override/default/conf] --subject "subject line" --to recipient@email.tld
+
+  # directed file contents in using '<', typical unix syntax
+  asgs_sendmail.pl [-c override/default/conf] --subject "subject line" --to recipient@email.tld < body.txt
+
+=head2 Multiple Recipients
+
+The C<--to> options accepts a comma delimited list of email addresses:
+
+  some-utility | asgs_sendmail.pl [-c override/default/conf] --subject "subject line" --to "recipient1@email.tld, recipient2@email.tld, ..., recipientN@email.tld"
+
+=head1 DESCRIPTION
+
+This utility is used to send emails using an external SMTP server.
+
+=head1 OPTIONS
+
+=head2 Required
+
+=over4
+
+=item C<--to>
+
+One or more recipients must be defined. If more than one, pass in as a comma delimted string. See perldoc for more information (POD at the end of this file).
+
+=back
+
+=head2 Optional
+
+=over4
+
+=item C<--c>
+
+Define a non-default configuration file. See below for the format involved in creating the configuration file used by this script.
+
+=item C<--subject>
+
+Defines subject thread. There is a default, but it's meaningless.
+
+=back
+=head1 CONFIGURATION
+
+By default, a configuration file located at $HOME/asgs-global.conf is
+required. This file contains the necessary authoriziation information
+required for sending emails through an external SMTP server gateway.
+TLS (port 587) is a preferred transport for security reasons, but the
+underlying module supports SSL and unecrypted (port 25).
+
+  [email]
+  from_address=info@stormsurge.email
+  mail_reply_to=info@stormsurge.email
+  smtp_host=smtp.host.name
+  smtp_port=587 
+  smtp_username=smtp-username
+  smtp_password=smtp-password
+
+=head1 LIMITATIONS
+
+Currently, the content of the body of the message must be provided
+via STDIN, this means it must be piped in via an external source.
+This source could be another program or an existing file.

--- a/output/emailattach.py
+++ b/output/emailattach.py
@@ -6,14 +6,17 @@
 #  % python emailattach.py "comma, delimited, list, of, addresses" "subject" "body text file" "from" "mailserver" "space delimited list of attachments ad infinitum..."
 #
 
+import os
+import sys
 import smtplib
+import ConfigParser
+import os.path
 from email.MIMEMultipart import MIMEMultipart
 from email.MIMEBase import MIMEBase
 from email.MIMEText import MIMEText
 from email.Utils import COMMASPACE, formatdate
 from email import Encoders
-import os
-import sys
+from os.path import expanduser
 
 def sendMail(to, subject, text, fro, server, files=[]):
     assert type(to)==list
@@ -27,6 +30,13 @@ def sendMail(to, subject, text, fro, server, files=[]):
 
     msg.attach( MIMEText(text) )
 
+    # look for SMTP config file
+    home = expanduser("~")
+    config_file = home + '/asgs-global.conf'
+    config = ConfigParser.ConfigParser()
+    config.read(config_file)
+    dConfig = config.__dict__['_sections'].copy()
+
     for filein in files:
         part = MIMEBase('application', "octet-stream")
         part.set_payload( open(filein,"rb").read() )
@@ -35,9 +45,18 @@ def sendMail(to, subject, text, fro, server, files=[]):
                        % os.path.basename(filein))
         msg.attach(part)
 
-    smtp = smtplib.SMTP(server)
-    smtp.sendmail(fro, to, msg.as_string() )
-    smtp.close()
+    if os.path.isfile(config_file): 
+        # 'server' and 'fro' params passed in are ignored if config_file is detected
+        smtp = smtplib.SMTP(dConfig['email']['smtp_host'])
+        smtp.starttls()
+        smtp.ehlo(dConfig['email']['smtp_host']);
+        smtp.login(dConfig['email']['smtp_username'],dConfig['email']['smtp_password']); 
+        smtp.sendmail(dConfig['email']['from_address'], to, msg.as_string() )
+        smtp.close()
+    else:
+        smtp = smtplib.SMTP(server) # for when smtp is not external (need a check)
+        smtp.sendmail(fro, to, msg.as_string() )
+        smtp.close()
 
 if __name__ == "__main__":
     addresslist = sys.argv[1].split(",")


### PR DESCRIPTION
Issue-95: Added a commandline tool for email integration with AWS
SES via SMTP. Credentials and set up are required, as are additional
Perl modules. The perlbrew README was updated, list of modules updated,
and a README for setting up email was added.