### PR TITLE
Fixed relocatability bug in asgs-brew.pl

### DIFF
--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -640,7 +640,7 @@ sub get_steps {
             precondition_check  => sub { return ( -e qq{$home/perl5/perlbrew/perls/perl-5.28.2/bin/perl} ) ? 1 : 0 },
             postcondition_check => sub {
                 local $?;
-                system(qq{prove $home/asgs/cloud/general/t/verify-perl-modules.t 2>&1});
+                system(qq{prove ./cloud/general/t/verify-perl-modules.t 2>&1});
 
                 # look for zero exit code on success
                 my $exit_code = ( $? >> 8 );
@@ -664,7 +664,7 @@ sub get_steps {
             precondition_check  => sub { 1 },    # for now, assuming success; should have a simple python script that attempts to load all of these modules
             postcondition_check => sub {
                 local $?;
-                system(qq{$home/asgs/cloud/general/t/verify-python-modules.py 2>&1});
+                system(qq{./cloud/general/t/verify-python-modules.py 2>&1});
 
                 # look for zero exit code on success
                 my $exit_code = ( $? >> 8 );


### PR DESCRIPTION
Issue #171: some of the steps in asgs-brew.pl had references to
$HOME and broke when trying to install it into alternative locations.
This fix removes the fragility and should allow ASGS to be installed
anywhere, to anywhere. Access to a $USER's true $HOME is needed for
Perl, Python, and asgsh; since these 3 components are meant to serve
all of an operators installations globally.