### PR TITLE
Removed immediate "git clone" of asgs repository in init-asgs.sh.

### DIFF
--- a/init-asgs.sh
+++ b/init-asgs.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 
-if [ ! -d $HOME/asgs ]; then
-  git clone https://github.com/jasonfleming/asgs.git
-  if [ $? -gt 0 ]; then
-    echo error cloning ASGS
-    exit 1
-  fi
-fi
+# This file is part of the ADCIRC Surge Guidance System (ASGS).
+#
+# The ASGS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ASGS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
+#----------------------------------------------------------------
 
 echo "pod            - POD (Penguin)"
 echo "hatteras       - Hatteras (RENCI)"


### PR DESCRIPTION
Issue #199: Checking for $HOME/asgs and running 'git clone' to
download the current ASGS repository was an artifact from earlier
development and should not have been there. Removed this check. Also
added header information regarding the license for this script.