### PR TITLE
Adding initial Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# Note: Dockerfile is not meant to be built by users,
+# but is meant to build the ASGS docker image avaiable
+# to users via https://hub.docker.com (pending) by ASGS
+# maintainers when a new release is tagged.
+#
+# Note: image doesn't contain ADCIRC source or binaries;
+# run `initadcirc` in ASGS Shell to obtain.
+#
+# Build command: (used when publishing a new image to dockerhub)
+#
+#   docker build -t asgsdockerhub/2019stable .
+#
+# Run command:   (used by most, drops them directly to the ASGS Shell prompt)
+#
+#   docker pull asgsdockerhub/2019stable    # get from dockerhub
+#   docker run -it asgsdockerhub/2019stable # create running container from pulled image
+
+# docker image is based on ubuntu
+FROM ubuntu
+RUN apt-get update
+
+# install required libraries and tools
+RUN apt-get install -y build-essential checkinstall
+RUN apt-get install -y zlib1g-dev
+RUN apt-get install -y libssl-dev
+RUN apt-get install -y gfortran
+RUN apt-get install -y python-pip
+RUN apt-get install -y python2.7
+RUN apt-get install -y wget curl vim
+RUN apt-get install -y git
+
+# link env to expected path
+RUN ln -s /usr/bin/env /bin/env > /dev/null 2>&1 || echo /usr/bin/env already links to /bin/env
+
+# get tarball of ASGS, "2019stable"
+RUN wget https://github.com/jasonfleming/asgsdockerhub/archive/2019stable.tar.gz
+
+# unarchive/compress, install
+RUN tar zxvf /2019stable.tar.gz
+RUN mv /asgs-2019stable /asgs
+
+# fix minor issue with an upstream failing test in Date::Handler,
+# which is not an ASGS bug, but not handled; this line should go
+# away in future releases of ASGS
+RUN perl -pi -e 's/Date::Format/Date::Format Date::Handler/g' /asgs/cloud/general/init-perl-modules.sh
+
+# directly runs asgs-brew.pl
+RUN cd /asgs && ./cloud/general/asgs-brew.pl --machinename vagrant --compiler gfortran --asgs-profile default
+
+# run whenever user creates a running container of this image
+# via `docker run -it asgsdockerhub/2019stable`
+ENTRYPOINT cd /asgs &&/root/bin/asgsh

--- a/Dockerfile.git-master
+++ b/Dockerfile.git-master
@@ -1,0 +1,16 @@
+FROM ubuntu
+RUN apt-get update
+RUN apt-get install -y build-essential checkinstall
+RUN apt-get install -y zlib1g-dev
+RUN apt-get install -y libssl-dev
+RUN apt-get install -y gfortran
+RUN apt-get install -y python-pip
+RUN apt-get install -y python2.7
+RUN apt-get install -y wget curl vim
+RUN ln -s /usr/bin/env /bin/env > /dev/null 2>&1 || echo /usr/bin/env already links to /bin/env
+RUN apt-get install -y git
+RUN git clone https://github.com/jasonfleming/asgs.git
+RUN cd /asgs && git remote rename origin upstream && git pull upstream master
+RUN perl -pi -e 's/Date::Format/Date::Format Date::Handler/g' /asgs/cloud/general/init-perl-modules.sh
+RUN cd /asgs && ./cloud/general/asgs-brew.pl --machinename vagrant --compiler gfortran --asgs-profile default
+ENTRYPOINT cd /asgs &&/root/bin/asgsh

--- a/cloud/general/init-perl-modules.sh
+++ b/cloud/general/init-perl-modules.sh
@@ -10,7 +10,12 @@ if [ ! -e $HOME/perl5/perlbrew/bin/cpanm ]; then
 fi
 
 echo Installing Perl modules required for ASGS
-cpanm install --notest Date::Format  # due to this failing test https://rt.cpan.org/Public/Bug/Display.html?id=124509
+
+# due to failing tests that do not affect usefullness
+# the module 
+cpanm install --notest Date::Format
+cpanm install --notest Date::Handler
+
 for module in $(cat ./PERL-MODULES); do
   cpanm install $module || exit 1 # forces script to exit with error, asgs-brew.pl will catch and report this
 done


### PR DESCRIPTION
Issue #165: Adding a Dockerfile to support the evaluation,
exploration, and local use of the 2019stable release of ASGS.
The Dockerfile is used by a developer or maintainer when after
a release when they wish to make a Docker image of the environment
available at https://hub.docker.com.

This change also includes a minor change to the script that installs
the Perl modules because during the development of the Dockerfile,
it was discovered that the upstream version of Date::Handler had some
failing tests that were preventing the module from being installed.
This was through no fault of ASGS, nor does it appear that this test
failing affects ASGS in any negative way.