### PR TITLE
Adding Dockerfile and scripts used for storm replay infrastructure.

### DIFF
--- a/cloud/replay-server/Dockerfile
+++ b/cloud/replay-server/Dockerfile
@@ -1,0 +1,23 @@
+FROM centos:7
+
+ARG USER_ID=14
+ARG GROUP_ID=50
+
+RUN yum -y update && yum clean all
+RUN yum install -y \
+	vsftpd \
+	db4-utils \
+	db4 && yum clean all
+
+RUN usermod -u ${USER_ID} ftp
+RUN groupmod -g ${GROUP_ID} ftp
+
+COPY vsftpd.conf /etc/vsftpd/
+
+COPY run-vsftpd.sh /usr/sbin/
+RUN chmod +x /usr/sbin/run-vsftpd.sh
+RUN chown -R ftp:ftp /var/ftp
+
+EXPOSE 20 21
+
+ENTRYPOINT ["/usr/sbin/run-vsftpd.sh"]

--- a/cloud/replay-server/README
+++ b/cloud/replay-server/README
@@ -1,0 +1,57 @@
+The Dockerfile included sets up an anonymous ftp using the
+vsftp daemon. It is based on the Dockerfile for vsftp via
+https://github.com/fauria/docker-vsftpd.
+
+Summary:
+
+Provided in this directory are the files needed to set up ftp and
+web services that mimic what is provided for by the NHC when issuing
+the advisories during a tropical event that ASGS uses to trigger new
+simulations. It is meant primarily to facilitate pre-season drills
+and is a work in progress.
+
+Assumptions:
+
+1. Docker has been set up on publicly accessible server running vsftpd
+   and nginx (Ubuntu running on Digital Ocean with public IP address works
+   great)
+2. a user named "user" has been set up
+3. the following directories exist:
+
+  /home/user/rss-data       # docroot used by nginx container (location of index-at.xml RSS file)
+  /home/user/data           # root ftp directory mapped to /var/ftp on the vsftpd container
+  /home/user/data/atcf      # beginning of NHC-like directory structure
+  /home/user/data/atcf/btk  # location of "best track" data files and index-at.xml RSS file
+  /home/user/data/atcf/afst # location of forecast data file
+
+Setting up Services:
+
+Currently there is no container provided at Docker hub, so the image for
+vsftpd must be created locally:
+
+  docker build -t vsftpd/anonymous .
+
+  Note: there is no need to build the nginx container since it uses the one
+  that is already available via Docker Hub
+
+Once this is done, there are 2 start scripts for the vsftpd and nginx servers:
+
+  ./start-ftp.sh
+
+  ./start-www.sh
+
+The commands they contain are:
+
+  # starting vsftpd (port 21, passive mode, anonymous ftp, NOT writeable)
+
+  docker run -d -p 20:20 -p 21:21 -p 21100-21110:21100-21110 --restart always -v /home/user/data:/var/ftp:ro vsftpd/anonymous 
+
+  # starting nginx (port 80)
+
+  docker -v /home/user/data/rss-data:/usr/share/nginx/html:ro --restart always -d nginx
+
+Rotating Forecasts:
+
+There is a script in development to facilitate this, but it's a work in progress. The
+above information provides a good basis to start if one wishes to facilitte their
+own storm replaying.

--- a/cloud/replay-server/run-vsftpd.sh
+++ b/cloud/replay-server/run-vsftpd.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# NOTE: this is used during the building of the Docker container
+
+# Run vsftpd:
+&>/dev/null /usr/sbin/vsftpd /etc/vsftpd/vsftpd.conf

--- a/cloud/replay-server/start-ftp.sh
+++ b/cloud/replay-server/start-ftp.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# for FTP
+docker run -d -p 20:20 -p 21:21 -p 21100-21110:21100-21110 --restart always -v /home/user/data:/var/ftp:ro vsftpd/anonymous 

--- a/cloud/replay-server/start-www.sh
+++ b/cloud/replay-server/start-www.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker -v /home/user/data/rss-data:/usr/share/nginx/html:ro --restart always -d nginx

--- a/cloud/replay-server/vsftpd.conf
+++ b/cloud/replay-server/vsftpd.conf
@@ -1,0 +1,60 @@
+# Run in the foreground to keep the container running:
+background=NO
+
+# Allow anonymous FTP? (Beware - allowed by default if you comment this out).
+anonymous_enable=YES
+
+# Uncomment this to allow local users to log in.
+local_enable=NO
+
+## Enable virtual users
+guest_enable=NO
+
+## Virtual users will use the same permissions as anonymous
+virtual_use_local_privs=NO
+
+# Uncomment this to enable any form of FTP write command.
+write_enable=NO
+
+## PAM file name
+#pam_service_name=vsftpd_virtual
+
+## Home Directory for virtual users
+#user_sub_token=$USER
+#@local_root=/home/vsftpd/data
+
+# You may specify an explicit list of local users to chroot() to their home
+# directory. If chroot_local_user is YES, then this list becomes a list of
+# users to NOT chroot().
+chroot_local_user=NO
+
+# Workaround chroot check.
+# See https://www.benscobie.com/fixing-500-oops-vsftpd-refusing-to-run-with-writable-root-inside-chroot/
+# and http://serverfault.com/questions/362619/why-is-the-chroot-local-user-of-vsftpd-insecure
+allow_writeable_chroot=NO
+
+## Hide ids from user
+hide_ids=YES
+
+## Enable logging
+xferlog_enable=YES
+xferlog_file=/var/log/vsftpd/vsftpd.log
+
+## Enable active mode
+port_enable=YES
+connect_from_port_20=NO
+ftp_data_port=20
+pasv_enable=YES
+pasv_max_port=21110
+pasv_min_port=21100
+pasv_addr_resolve=YES
+pasv_address=142.93.48.99
+
+## Disable seccomp filter sanboxing
+seccomp_sandbox=NO
+
+# dir list
+dirlist_enable=YES
+dirmessage_enable=YES
+message_file=.message
+anon_root=/var/ftp


### PR DESCRIPTION
Issue #214: The idea is to maintain a replay server for most to use,
but these files will help one get started if they wish to run their
very own replay services. This provides set up for anonymous FTP using
vsftpd and a web server for RSS using the stock nginx Docker container
at Docker Hub.