### PR TITLE
Added AdcGrid to the Perl module check available in asgsh.

### DIFF
--- a/cloud/general/t/verify-perl-modules.t
+++ b/cloud/general/t/verify-perl-modules.t
@@ -10,4 +10,6 @@ for my $module (<$fh>) {
   require_ok $module;
 }
 
+require_ok q{AdcGrid};
+
 done_testing();


### PR DESCRIPTION
Issue #184: Access to AdcGrid is implicitly proved during the
`perl -c` check, but adding it to the Perl module verification
check so there is no doubt.