### PR TITLE
Modified qscript.pl to handle single digit hour *WALLTIMEs.

### DIFF
--- a/qscript.pl
+++ b/qscript.pl
@@ -170,7 +170,7 @@ if ( $jobtype eq "padcirc" || $jobtype eq "padcswan" ){
 # 
 # compute wall clock time HH:MM:SS in minutes
 $walltime = $properties{"hpc.job.$jobtype.limit.walltime"};
-$walltime =~ /(\d{2}):(\d{2}):(\d{2})/;
+$walltime =~ /(\d+):(\d+):(\d+)/;
 $wallminutes = $1*60 + $2;
 #
 # get queue script template


### PR DESCRIPTION
Issue #239: Updated regex that extracts hour:minutes:seconds from
the *WALLTIME passed via --walltime option so that it can handle
single digit hours (and minutes and seconds).

Now accepts:

* 02:00:00
* 2:00:00
* 10:00:00
* etc

Fixes Issue #239.