### PR TITLE
Making ASGS aware of $HOME/.ssh/config for ssh-based connections.

### DIFF
--- a/output/asgsConvertR3ToNETCDF.pl
+++ b/output/asgsConvertR3ToNETCDF.pl
@@ -36,8 +36,6 @@ my $DeleteFiles=0;
 my $SendNotification=1;
 my $CopyFile=1;
 sub stderrMessage($$);
-my $sshkey;  # public key for scp'ing results to remote hosts
-my $opendapuser; # username for scp'ing results to remote hosts
 my $opendaphost; # hostname for scp'ing results 
 my $remoteppdir="/projects/ncfs/apps/asgs/trunk/output"; # netcdf post proc 
 # set the OpenDAP prefix:  Change this if/when we change where opendap.renci.org points.
@@ -87,7 +85,6 @@ GetOptions(
     "remoteppdir=s" => \$remoteppdir,
     "griddir=s" => \$GRIDDIR,
     "opendapbasedir=s" => \$OPENDAPBASEDIR,
-    "opendapuser=s" => \$opendapuser,
     "opendaphost=s" => \$opendaphost,
     "sshkey=s" => \$sshkey,
     "pathonly" => \$pathonly,
@@ -284,19 +281,19 @@ for (my $i=0; $i<($num_files/2); $i++ ) {
    my $from = pop(@filesProcessed);
    if ($CopyFile) {
       if ($remote) {
-         system("scp -i $sshkey $from $opendapuser\@$opendaphost:$openDAPDirectory/$to");
-         stderrMessage("INFO","Copying '$from' to '$opendapuser\@$opendaphost:$openDAPDirectory/$to'.");
+         system("scp $from $opendaphost:$openDAPDirectory/$to");
+         stderrMessage("INFO","Copying '$from' to '$opendaphost:$openDAPDirectory/$to'.");
       if ($from eq "maxele.63.nc.gz" || $from eq "fort.63.nc.gz" ) {
          if ( -e $from ) {
-            stderrMessage("INFO","Performing remote decompression on '$opendapuser\@$opendaphost:$openDAPDirectory/$to'.");
-            system("ssh $opendaphost -l $opendapuser -i $sshkey \"gunzip $openDAPDirectory/$to\""); # decompress the data
+            stderrMessage("INFO","Performing remote decompression on '$opendaphost:$openDAPDirectory/$to'.");
+            system("ssh $opendaphost \"gunzip $openDAPDirectory/$to\""); # decompress the data
             my $basename =substr($to,0,-3);
-            stderrMessage("INFO","Performing remote append of depth data and inundation masks on '$opendapuser\@$opendaphost:$openDAPDirectory/$basename'.");
-            system("ssh $opendaphost -l $opendapuser -i $sshkey \"ncks --quiet --append $remoteppdir/FEMA_R3_draft_20110303_MSL.nc $openDAPDirectory/$basename\""); # append depth data and inundation masks
-            stderrMessage("INFO","Performing remote calculation of inundation on '$opendapuser\@$opendaphost:$openDAPDirectory/$basename'.");
-            system("ssh $opendaphost -l $opendapuser -i $sshkey \"ncap2 --overwrite -S $remoteppdir/produceInundationData.scr $openDAPDirectory/$basename $openDAPDirectory/$basename\"");     # calculate inundation level     
-            stderrMessage("INFO","Performing remote compression on '$opendapuser\@$opendaphost:$openDAPDirectory/$basename'.");
-            system("ssh $opendaphost -l $opendapuser -i $sshkey \"gzip --force $openDAPDirectory/$basename\""); # recompress the data
+            stderrMessage("INFO","Performing remote append of depth data and inundation masks on '$opendaphost:$openDAPDirectory/$basename'.");
+            system("ssh $opendaphost \"ncks --quiet --append $remoteppdir/FEMA_R3_draft_20110303_MSL.nc $openDAPDirectory/$basename\""); # append depth data and inundation masks
+            stderrMessage("INFO","Performing remote calculation of inundation on '$opendaphost:$openDAPDirectory/$basename'.");
+            system("ssh $opendaphost \"ncap2 --overwrite -S $remoteppdir/produceInundationData.scr $openDAPDirectory/$basename $openDAPDirectory/$basename\"");     # calculate inundation level     
+            stderrMessage("INFO","Performing remote compression on '$opendaphost:$openDAPDirectory/$basename'.");
+            system("ssh $opendaphost \"gzip --force $openDAPDirectory/$basename\""); # recompress the data
       }
    }
       } else {

--- a/output/opendap_post.sh
+++ b/output/opendap_post.sh
@@ -83,6 +83,8 @@ THIS="output/opendap_post.sh"
 OPENDAPMAILSERVER=${properties["notification.opendap.email.opendapmailserver"]}
 declare -a LINKABLEHOSTS
 declare -a COPYABLEHOSTS
+timeoutRetryLimit=${timeoutRetryLimit:-3}
+serverAliveInterval=${serverAliveInterval:-10}
 #
 for server in ${SERVERS[*]}; do
    if [[ $server = "(" || $server = ")" ]]; then 
@@ -103,8 +105,6 @@ for server in ${SERVERS[*]}; do
    DOWNLOADPREFIX=${properties["post.opendap.${server}.downloadprefix"]}
    CATALOGPREFIX=${properties["post.opendap.${server}.catalogprefix"]} 
    OPENDAPBASEDIR=${properties["post.opendap.${server}.opendapbasedir"]}
-   SSHPORT=${properties["post.opendap.${server}.sshport"]}
-   OPENDAPUSER=${properties["post.opendap.${server}.opendapuser"]}
    #
    #--------------------------------------------------------------------
    #  O P E N  D A P    P A T H   F O R M A T I O N
@@ -218,16 +218,10 @@ END
    scenarioMessage "$SCENARIO: $THIS: Posting to $OPENDAPHOST using the '$OPENDAPPOSTMETHOD' method."
    case $OPENDAPPOSTMETHOD in
    "scp")
-      serverAliveInterval=10
-      timeoutRetryLimit=3
-      sshOptions="$OPENDAPHOST -l $OPENDAPUSER -p $SSHPORT -o ServerAliveInterval=$serverAliveInterval -o StrictHostKeyChecking=no -o ConnectTimeout=60"
-      echo "post.opendap.${server}.sshoptions : $sshOptions" >> run.properties 2>> $SYSLOG
-      scpOptions="-P $SSHPORT -o ServerAliveInterval=$serverAliveInterval -o StrictHostKeyChecking=no -o ConnectTimeout=60"
-      echo "post.opendap.${server}.scpoptions : $scpOptions" >> run.properties 2>> $SYSLOG
-      scenarioMessage "$SCENARIO: $THIS: Transferring files to $OPENDAPDIR on $OPENDAPHOST as user $OPENDAPUSER."
+      scenarioMessage "$SCENARIO: $THIS: Transferring files to $OPENDAPDIR on $OPENDAPHOST."
       retry=0
       while [[ $retry -lt $timeoutRetryLimit ]]; do 
-         ssh $sshOptions "mkdir -p $OPENDAPDIR" >> $SCENARIOLOG 2>&1
+         ssh $OPENDAPHOST "mkdir -p $OPENDAPDIR" >> $SCENARIOLOG 2>&1
          if [[ $? != 0 ]]; then
             warn "$SCENARIO: $THIS: Failed to create the directory $OPENDAPDIR on the remote machine ${OPENDAPHOST}."
             threddsPostStatus=fail
@@ -249,7 +243,7 @@ END
       while [[ $partialPath != $OPENDAPBASEDIR  ]]; do 
          retry=0
          while [[ $retry -lt $timeoutRetryLimit ]]; do 
-            ssh $sshOptions "chmod a+wx $partialPath" 2>> $SYSLOG
+            ssh $OPENDAPHOST "chmod a+wx $partialPath" 2>> $SYSLOG
             if [[ $? != 0 ]]; then
                warn "$SCENARIO: $THIS: Failed to change permissions on the directory $partialPath on the remote machine ${OPENDAPHOST}."
                threddsPostStatus=fail
@@ -273,7 +267,7 @@ END
       if [[ $TROPICALCYCLONE != off ]]; then 
          retry=0
          while [[ $retry -lt $timeoutRetryLimit ]]; do 
-            ssh $sshOptions "ln -s $OPENDAPBASEDIR/$STORMNAMEPATH $OPENDAPBASEDIR/$ALTSTORMNAMEPATH" 2>> $SYSLOG
+            ssh $OPENDAPHOST "ln -s $OPENDAPBASEDIR/$STORMNAMEPATH $OPENDAPBASEDIR/$ALTSTORMNAMEPATH" 2>> $SYSLOG
             if [[ $? != 0 ]]; then
                warn "$SCENARIO: $THIS: Failed to create symbolic link for the storm name."
                threddsPostStatus=fail
@@ -314,7 +308,7 @@ END
          scenarioMessage "$SCENARIO: $THIS: Transferring $file to ${OPENDAPHOST}:${OPENDAPDIR}."
          retry=0
          while [[ $retry -lt $timeoutRetryLimit ]]; do 
-            scp $scpOptions $file ${OPENDAPUSER}@${OPENDAPHOST}:${OPENDAPDIR} >> $SCENARIOLOG 2>&1
+            scp $file ${OPENDAPHOST}:${OPENDAPDIR} >> $SCENARIOLOG 2>&1
             if [[ $? != 0 ]]; then
                threddsPostStatus=fail
                warn "$SCENARIO: $THIS: Failed to transfer the file $file to ${OPENDAPHOST}:${OPENDAPDIR}."
@@ -333,7 +327,7 @@ END
          fname=`basename $file` 
          retry=0
          while [[ $retry -lt $timeoutRetryLimit ]]; do 
-            ssh $sshOptions "chmod +r $OPENDAPDIR/$fname"
+            ssh $OPENDAPHOST "chmod +r $OPENDAPDIR/$fname"
             if [[ $? != 0 ]]; then
                threddsPostStatus=fail
                warn "$SCENARIO: $THIS: Failed to give the file $fname read permissions in ${OPENDAPHOST}:${OPENDAPDIR}."
@@ -356,14 +350,11 @@ END
    #-------------------------------------------------------------------
    # mvb20190618: Added to support time-out issues with general scp transfers
    "rsync")
-      rsyncSSHOptions=(--rsh="ssh -p $SSHPORT")
       echo "post.opendap.${server}.rsyncsshoptions : $rsyncSSHOptions" >> run.properties 2>> $SYSLOG
       rsyncOptions="-z --copy-links"
       echo "post.opendap.${server}.rsyncoptions : $rsyncOptions" >> run.properties 2>> $SYSLOG
-      sshOptions="$OPENDAPHOST -l $OPENDAPUSER -p $SSHPORT"
-      echo "post.opendap.${server}.sshoptions : $sshOptions" >> run.properties 2>> $SYSLOG
-      allMessage "$SCENARIO: $THIS: Transferring files to $OPENDAPDIR on $OPENDAPHOST as user $OPENDAPUSER."
-      ssh $sshOptions "mkdir -p $OPENDAPDIR" >> $SCENARIOLOG 2>&1
+      allMessage "$SCENARIO: $THIS: Transferring files to $OPENDAPDIR on $OPENDAPHOST."
+      ssh $OPENDAPHOST "mkdir -p $OPENDAPDIR" >> $SCENARIOLOG 2>&1
       if [[ $? != 0 ]]; then
          warn "$SCENARIO: $THIS: Failed to create the directory $OPENDAPDIR on the remote machine ${OPENDAPHOST}."
          threddsPostStatus=fail
@@ -374,7 +365,7 @@ END
       while [[ $partialPath != $OPENDAPBASEDIR  ]]; do 
          retry=0
          while [[ $retry -lt $timeoutRetryLimit ]]; do 
-            ssh $sshOptions "chmod a+wx $partialPath" 2>> $SYSLOG
+            ssh $OPENDAPHOST "chmod a+wx $partialPath" 2>> $SYSLOG
             if [[ $? != 0 ]]; then
                warn "$SCENARIO: $THIS: Failed to change permissions on the directory $partialPath on the remote machine ${OPENDAPHOST}."
                threddsPostStatus=fail
@@ -411,7 +402,7 @@ END
          fi
          chmod +r $file 2>> $SYSLOG
          scenarioMessage "$SCENARIO: $THIS: Transferring $file to ${OPENDAPHOST}:${OPENDAPDIR}."
-         rsync "${rsyncSSHOptions}" ${rsyncOptions}  ${file} ${OPENDAPUSER}@${OPENDAPHOST}:${OPENDAPDIR} >> $SCENARIOLOG 2>&1
+         rsync ${rsyncOptions} ${file} ${OPENDAPHOST}:${OPENDAPDIR} >> $SCENARIOLOG 2>&1
          if [[ $? != 0 ]]; then
             threddsPostStatus=fail
             warn "$SCENARIO: $THIS: Failed to transfer the file $file to ${OPENDAPHOST}:${OPENDAPDIR}."

--- a/output/r3_post.sh
+++ b/output/r3_post.sh
@@ -99,6 +99,6 @@ fi
 REMOTEPPDIR=/projects/ncfs/apps/asgs/trunk/output
 perl ${OUTPUTDIR}/asgsConvertR3ToNETCDF.pl --ppdir ${SCRIPTDIR}/output --griddir ${OUTPUTDIR}/POSTPROC_KMZGIS/grids --opendapbasedir $OPENDAPBASEDIR --pathonly
 OPENDAPPATH=`cat opendappath.log`
-ssh ${OPENDAPHOST} -l ${OPENDAPUSER} -i $SSHKEY "mkdir -p $OPENDAPPATH"
+ssh ${OPENDAPHOST} "mkdir -p $OPENDAPPATH"
 perl ${OUTPUTDIR}/asgsConvertR3ToNETCDF.pl --ppdir ${SCRIPTDIR}/output --remoteppdir $REMOTEPPDIR  --griddir ${OUTPUTDIR}/POSTPROC_KMZGIS/grids --opendapbasedir $OPENDAPBASEDIR --remote --sshkey $SSHKEY --opendapuser $OPENDAPUSER --opendaphost $OPENDAPHOST --tolist "jason.fleming@seahorsecoastal.com, jason.g.fleming@gmail.com"
-ssh ${OPENDAPHOST} -l ${OPENDAPUSER} -i $SSHKEY "chmod +r $OPENDAPPATH/*"
+ssh ${OPENDAPHOST} "chmod +r $OPENDAPPATH/*"

--- a/platforms.sh
+++ b/platforms.sh
@@ -677,7 +677,6 @@ writeTDSProperties()
    SERVER=$1
    CATALOGPREFIX=""    # after thredds/catalog
    DOWNLOADPREFIX=""   # after thredds/fileServer
-   OPENDAPUSER=$operator
    OPENDAPMAILSERVER=mailx  # this is the local default mail server executable on the HPC
    case $SERVER in
    "renci_tds")
@@ -685,16 +684,12 @@ writeTDSProperties()
       # http://tds.renci.org:8080/thredds/fileServer/DataLayers/asgs/tc/nam/2018070806/ec_95d/pod.penguin.com/podtest/namforecast/maxele.63.nc
       # http://tds.renci.org:8080/thredds/dodsC/     DataLayers/asgs/tc/nam/2018070806/ec_95d/pod.penguin.com/podtest/namforecast/maxele.63.nc
       # http://tds.renci.org:8080/thredds/catalog/                   tc/nam/2018070806/ec_95d/pod.penguin.com/podtest/namforecast/catalog.html
-      OPENDAPHOST=ht4.renci.org
-      THREDDSHOST=tds.renci.org
+      THREDDSHOST=tds.renci.org # WWW hostname for emailed links
+      OPENDAPHOST=renci_tds     # alias in $HOME/.ssh/config
       OPENDAPPORT=":8080"
       OPENDAPBASEDIR=/projects/ncfs/opendap/data
-      SSHPORT=22
       echo "post.opendap.${SERVER}.linkablehosts : ( null )" >> run.properties
       echo "post.opendap.${SERVER}.copyablehosts : ( hatteras )" >> run.properties
-      if [[ $operator = jgflemin ]]; then
-         OPENDAPUSER=ncfs
-      fi
       #DOWNLOADPREFIX="http://tds.renci.org:8080/thredds/fileServer/DataLayers/asgs/"
       #CATALOGPREFIX="http://tds.renci.org:8080/thredds/DataLayers/asgs/"
       #OPENDAPBASEDIR=/projects/ees/DataLayers/asgs/
@@ -702,30 +697,22 @@ writeTDSProperties()
 
    # THREDDS Data Server (TDS, i.e., OPeNDAP server) at LSU
    "lsu_tds") 
-      OPENDAPHOST=fortytwo.cct.lsu.edu
-      THREDDSHOST=$OPENDAPHOST
+      THREDDSHOST=fortytwo.cct.lsu.edu
+      OPENDAPHOST=lsu_tds
       OPENDAPPORT=":443"
       OPENDAPBASEDIR=/data/opendap
-      SSHPORT=2525
-      if [[ $USER = "ncfs" || $USER = "jgflemin" ]]; then
-         OPENDAPUSER="jgflemin"
-      fi
       echo "post.opendap.${SERVER}.linkablehosts : ( null )" >> run.properties
       echo "post.opendap.${SERVER}.copyablehosts : ( null )" >> run.properties
       ;;
 
    # THREDDS Data Server (TDS, i.e., OPeNDAP server) at LSU Center for Coastal Resiliency
    "lsu_ccr_tds")
-      OPENDAPHOST=chenier.cct.lsu.edu
-      THREDDSHOST=$OPENDAPHOST
+      THREDDSHOST=chenier.cct.lsu.edu # WWW hostname for emailed links
+      OPENDAPHOST=lsu_ccr_tds         # alias in $HOME/.ssh/config
       OPENDAPPORT=":8080"
       CATALOGPREFIX=/asgs/ASGS-2019
       DOWNLOADPREFIX=/asgs/ASGS-2019
       OPENDAPBASEDIR=/data/thredds/ASGS/ASGS-2019
-      SSHPORT=2525
-      if [[ $USER = "ncfs" || $USER = "jgflemin" ]]; then
-         OPENDAPUSER="jgflemin"
-      fi
       echo "post.opendap.${SERVER}.linkablehosts : ( null )" >> run.properties
       echo "post.opendap.${SERVER}.copyablehosts : ( null )" >> run.properties
       ;;
@@ -733,16 +720,12 @@ writeTDSProperties()
    # THREDDS Data Server (TDS, i.e., OPeNDAP server) at Texas
    # Advanced Computing Center (TACC)
    "tacc_tds")
-      OPENDAPHOST=adcircvis.tacc.utexas.edu
-      THREDDSHOST=$OPENDAPHOST
+      THREDDSHOST=adcircvis.tacc.utexas.edu # WWW hostname for emailed links
+      OPENDAPHOST=tacc_tds                  # alias in $HOME/.ssh/config
       OPENDAPPORT=":8080"
       DOWNLOADPREFIX=/asgs
       CATALOGPREFIX=/asgs
       OPENDAPBASEDIR=/corral-tacc/utexas/hurricane/ASGS
-      SSHPORT=null
-      if [[ $USER = "ncfs" || $USER = "jgflemin" ]]; then
-         OPENDAPUSER="jgflemin"
-      fi
       echo "post.opendap.${SERVER}.linkablehosts : ( null )" >> run.properties
       echo "post.opendap.${SERVER}.copyablehosts : ( lonestar5 stampede2 frontera )" >> run.properties
       ;;
@@ -755,8 +738,6 @@ writeTDSProperties()
    echo "post.opendap.${SERVER}.downloadprefix : http://$THREDDSHOST$OPENDAPPORT/thredds/fileServer$DOWNLOADPREFIX" >> run.properties
    echo "post.opendap.${SERVER}.catalogprefix : http://$THREDDSHOST$OPENDAPPORT/thredds/catalog$CATALOGPREFIX" >> run.properties
    echo "post.opendap.${SERVER}.opendapbasedir : $OPENDAPBASEDIR" >> run.properties
-   echo "post.opendap.${SERVER}.sshport : $SSHPORT" >> run.properties
-   echo "post.opendap.${SERVER}.opendapuser : $OPENDAPUSER" >> run.properties
    # if the Operator has an asgs-global.conf file, assume that a perl mail client capability is 
    # set up and ready to use
    # FIXME: create something more reliable/repeatable


### PR DESCRIPTION
With the addition of an ssh config under the control of the operator,
the scripts need only to reference the Host alias as defined in
$HOME/.ssh/config. Under each stanza, any of the existing parameters
may be changed (Username, Port, etc) as well as any ssh or scp
options. Since rsync uses ssh by default, it would automatically
derive host specific settings by virtue of using the Host alias as
the reference to the remote server.

This change separates the concerns of ASGS from managing ssh usernames,
hosts, private keys, and "-o" options to focusing on using ssh connections
on a higher level for interacting with remote servers.

The change also allows operators to draw from the same basic ssh config
file, requiring them to only ensure that their respective usernames and
paths to private keys are correct. The list of servers and ssh options
can be maintained and be consistent across the entire effort and in
conjunction with resource administrators.

Resolves Issue #131.