### PR TITLE
Pinned pip module versions and cleaned up python installation script.

### DIFF
--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -573,6 +573,8 @@ sub get_steps {
     my $adcirc_git_url    = $opts_ref->{'adcirc-git-url'};
     my $adcirc_git_branch = $opts_ref->{'adcirc-git-branch'};
     my $adcirc_git_repo   = $opts_ref->{'adcirc-git-repo'};
+    my $pythonversion     = q{2.7.18};
+    my $pythonpath        = qq{$asgs_install_path/python27/asgs/build/python-$pythonversion};
 
     my $steps = [
         {
@@ -819,13 +821,13 @@ sub get_steps {
 
                 # putting this in $HOME/python27/asgs/build reflects what perlbrew's default
                 # behavior is doing by putting perl into $HOME/perl5/perlbrew/build/perl-$version
-                PYTHONPATH => { value => qq{$asgs_install_path/python27/asgs/build/python-2.7.18},                           how => q{replace} },
-                PATH       => { value => qq{$asgs_install_path/python27/asgs/build/python-2.7.18/bin:$asgs_home/.local/bin}, how => q{prepend} },
+                PYTHONPATH => { value => $pythonpath,                               how => q{replace} },
+                PATH       => { value => qq{$pythonpath/bin:$asgs_home/.local/bin}, how => q{prepend} },
             },
-            command             => qq{bash ./cloud/general/init-python.sh install},
-            clean               => qq{bash ./cloud/general/init-python.sh clean},
+            command             => qq{bash ./cloud/general/init-python.sh install $pythonpath $pythonversion},
+            clean               => qq{bash ./cloud/general/init-python.sh clean   $pythonpath $pythonversion},
             skip_if             => sub { 0 },
-            precondition_check  => sub { 1 },                                         # for now, assuming success; should have a simple python script that attempts to load all of these modules
+            precondition_check  => sub { 1 },                                                                    # for now, assuming success; should have a simple python script that attempts to load all of these modules
             postcondition_check => sub {
                 local $?;
                 system(qq{./cloud/general/t/verify-python-modules.py 2>&1});

--- a/cloud/general/init-python.sh
+++ b/cloud/general/init-python.sh
@@ -7,8 +7,13 @@ PYTHON_VERSION=${3-2.7.18}
 TMP=$HOME/tmp
 
 if [ "$ACTION" == "clean" ]; then
-  rm -rfv $OPT/python/${PYTHON_VERSION} $HOME/.local
-  rm -rfv $PYTHONPATH
+  # remove installed binaries from upstream build
+  rm -rfv $OPT/python/${PYTHON_VERSION}
+  # remove modules and local pip directory
+  rm -rfv $HOME/.local
+  if [ -e "$TMP/Python-${PYTHON_VERSION}" ]; then
+    rm -rfv $TMP/Python-${PYTHON_VERSION} $TMP/Python-${PYTHON_VERSION}.tgz
+  fi
   echo
   echo Run again without clean flag to install
   echo
@@ -20,6 +25,11 @@ cd $TMP
 
 if [ ! -e ./Python-${PYTHON_VERSION}.tgz ]; then
   wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+fi
+if [ $? != 0 ]; then
+  echo Error downloading Python ${PYTHON_VERSION}. Please check access to the URL:
+  echo      https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+  exit $?
 fi
 
 rm -rf ./Python-${PYTHON_VERSION} 2> /dev/null
@@ -34,16 +44,15 @@ if [ ! -e $PYTHONPATH/bin/python ]; then
 fi
 
 _install_asgs_python_modules () {
-which python
-echo $PATH
-echo $PYTHONPATH
    cd $TMP
    wget https://bootstrap.pypa.io/get-pip.py -O ./get-pip.py
    python - --user < ./get-pip.py
-   pip install --user numpy -I
-   pip install --user pika -I
-   pip install --user netCDF4 -I
-   pip install --user python-pptx -I
+   pip install --user 'pika==1.1.0'         -I --force-reinstall
+   # version constrain is due to Unidata's drop in support of Python 2.7 in v1.5.4 of the netCDF4 module
+   pip install --user 'numpy==1.16.6'       -I --force-reinstall
+   # NOTE: installation of this netCDF4 installs numpy 1.16.6 if not specified before
+   pip install --user 'netCDF4==1.5.2'      -I --force-reinstall
+   pip install --user python-pptx           -I --force-reinstall
 }
 
 _install_asgs_python_modules


### PR DESCRIPTION
Issue #252: To ensure a compatible environment for Python 2.7, versions
for the modules installed via pip were pinned. This was most important
for the netCDF4 module, which removed support for Python 2.7. netCDF4
1.5.2 is also pinned to numpy 1.16.6, so that was also enforced at
the pip level when installing it explicitly. Internal changes to
asgs-brew.pl make it also a little easier to maintain version upgrades.
Even though upstream says there are no more Python 2.7 updates, they
a new minor version was released in March. It's highly likely they
will continue with minor changes like this from time to time to address
security issues and critical bugs, since 2.7 is likely to be heavily
used for many years to come due to it's large installation base.

Resolves #252.