### PR TITLE
Make asgs_main.sh aware of ADCIRCDIR if set in environment.

### DIFF
--- a/asgs_main.sh
+++ b/asgs_main.sh
@@ -1483,7 +1483,7 @@ variables_init()
    HOTORCOLD=coldstart
    LASTSUBDIR=null
    FTPSITE=null
-   ADCIRCDIR=null
+   ADCIRCDIR=${ADCIRCDIR:-null} # will respect ADCIRCDIR if already sent in the environment
    SCRATCHDIR=null
    MAILINGLIST=null
    QUEUESYS=null


### PR DESCRIPTION
Issue 246: Adds awareness to ASGS (asgs_main.sh) of the ADCIRCDIR
environmental variable if set, which is the case with an asgsh
profile when set up as recommended (e.g., using initadcirc and/or
load adcirc <adcirc-installation-name>).

The effective change here is that if ADCIRCDIR is set in the user's
environment when asgs_main.sh is executed, that this value is used
with out having to set it explicity in the ASGS configuratino file.
If ADCIRCDIR is not set or is set to an empty value, asgs_main.sh
will fall back to the traditional behavior of setting it to "null",
thus require ADCIRCDIR to be set explicitly in the configuration
file.

Issue #246 mentions other environmental variables ASGS should track,
but this commit only covers ADCIRCDIR since it provides immediate
value and alleviates some confusion experienced by operators who
are learning to use the shell environment.