### PR TITLE
Fixed init-asgs.sh guess for supermic.

### DIFF
--- a/init-asgs.sh
+++ b/init-asgs.sh
@@ -26,7 +26,7 @@
   elif [ 1 -eq $(hostname --fqdn | grep -c qb2) ]; then
     default_platform=queenbee
   elif [ 1 -eq $(hostname --fqdn | grep -c smic) ]; then
-    default_platform=smic
+    default_platform=supermic
   elif [ 1 -eq $(hostname --fqdn | grep -c ls5) ]; then
     default_platform=lonestar5
   elif [ 1 -eq $(hostname --fqdn | grep -c stampede2) ]; then


### PR DESCRIPTION
Issue #308: Was guessing as "smic". Should be "supermic" based on
what's defined in platforms.sh.

Resolves #308.