### PR TITLE
Complete SWAN binary support in building and adding to PATH.

### DIFF
--- a/cloud/general/DOT-asgs-brew.sh
+++ b/cloud/general/DOT-asgs-brew.sh
@@ -425,6 +425,11 @@ load() {
             echo -n linking $b
             ln -sf $ADCIRCDIR/$b $ASGS_INSTALL_PATH/bin/$b && echo ... ok
           done          
+          echo creating symlinks to SWAN binaries in $ASGS_INSTALL_PATH/bin
+          for b in $SWAN_BINS; do
+            echo -n linking $b
+            ln -sf $SWANDIR/$b $ASGS_INSTALL_PATH/bin/$b && echo ... ok
+          done          
           export PS1="asgs (${_ASGSH_CURRENT_PROFILE}*)> "
           echo "don't forget to save profile"
       else

--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -456,7 +456,7 @@ export _ASGSH_PID=\$\$
 
 # denotes which environmental variables we care about when saving a profile - includes variables that
 # are meaningful to ASGS Shell, but not set in asgs-brew.pl
-export _ASGS_EXPORTED_VARS="$_asgs_exported_vars _ASGS_EXPORTED_VARS WORK SCRATCH EDITOR PROPERTIESFILE INSTANCENAME RUNDIR SYSLOG ASGS_CONFIG ADCIRC_MAKE_CMD"
+export _ASGS_EXPORTED_VARS="$_asgs_exported_vars _ASGS_EXPORTED_VARS WORK SCRATCH EDITOR PROPERTIESFILE INSTANCENAME RUNDIR SYSLOG ASGS_CONFIG ADCIRC_MAKE_CMD SWAN_MAKE_CMD ADCIRC_BINS SWAN_BINS"
 $env_summary
 
 # export opts for processing in $rcfile
@@ -561,7 +561,7 @@ sub get_steps {
     #   Dev note: ADD new PATHs here using the existing pattern
     my $_get_all_paths = sub {
         my @all_paths = ();
-        push @all_paths, ( qq{$asgs_install_path/bini}, qq{$scriptdir/cloud/general} );
+        push @all_paths, ( qq{$asgs_install_path/bin}, qq{$scriptdir/cloud/general} );
         foreach my $dir (
             qw[  archive
             cloudgeneral
@@ -895,13 +895,13 @@ sub get_steps {
                 # always expose, always set even if not building ADCIRC
                 ADCIRC_GIT_BRANCH => { value => qq{$adcirc_git_branch}, how => q{replace} },
                 ADCIRC_GIT_URL    => { value => qq{$adcirc_git_url},    how => q{replace} },
+                ADCIRC_GIT_REPO   => { value => qq{$adcirc_git_repo},   how => q{replace} },
                 ADCIRC_COMPILER   => { value => qq{$asgs_compiler},     how => q{replace} },
 
                 # always expose, don't actually set unless building adcirc via asgs-brew.pl
                 ADCIRCBASE          => ( not $opts_ref->{'build-adcirc'} ) ? undef : { value => qq{$adcircdir-$adcirc_git_branch},      how => q{replace} },
                 ADCIRCDIR           => ( not $opts_ref->{'build-adcirc'} ) ? undef : { value => qq{$adcircdir-$adcirc_git_branch/work}, how => q{replace} },
                 SWANDIR             => ( not $opts_ref->{'build-adcirc'} ) ? undef : { value => qq{$adcircdir-$adcirc_git_branch/swan}, how => q{replace} },
-                ADCIRC_GIT_REPO     => ( not $opts_ref->{'build-adcirc'} ) ? undef : { value => qq{$adcirc_git_repo},                   how => q{replace} },
                 ADCIRC_PROFILE_NAME => ( not $opts_ref->{'build-adcirc'} ) ? undef : { value => qq{$adcirc_git_branch-$asgs_compiler},  how => q{replace} },
             },
             command => q{bash cloud/general/init-adcirc.sh},                   # Note: parameters input via environmental variables

--- a/cloud/general/init-adcirc.sh
+++ b/cloud/general/init-adcirc.sh
@@ -79,14 +79,16 @@ fi
 # looks for:
 # ASGS_MACHINE_NAME - passed to MACHINENAME of ADCIRC's Makefile, internally determines compiler flags and some library paths
 # NETCDFHOME        - tells ADCIRC where to look for NetCDF libraries
-# ADCIRCBASE         - main directory containing ADCIRC source code
+# ADCIRCBASE        - main directory containing ADCIRC source code
 # ADCIRC_COMPILER   - "intel" or "gfortran", set via --compiler in asgs-brew.pl
 # ADCIRC_GIT_BRANCH - passed to `git checkout`, set via --adcirc-git-branch in asgs-brew.pl
-# ADCIRC_GIT_URL - git repo remote URL, set via --adcirc-git-remote in asgs-brew.pl
+# ADCIRC_GIT_URL    - git repo remote URL, set via --adcirc-git-remote in asgs-brew.pl
 # ADCIRC_GIT_REPO   - git repository (likely 'adcirc-cg')
 
 ADCIRC_BINS="padcirc adcirc adcswan padcswan adcprep hstime aswip"
 ADCIRC_MAKE_CMD="make $ADCIRC_BINS SWAN=enable compiler=${ADCIRC_COMPILER} NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable NETCDFHOME=${NETCDFHOME} NETCDFROOT=${NETCDFROOT} MACHINENAME=${ASGS_MACHINE_NAME}"
+SWAN_BINS="unhcat.exe"
+SWAN_MAKE_CMD="make unhcat compiler=${ADCIRC_COMPILER} NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable NETCDFHOME=${NETCDFHOME} NETCDFROOT=${NETCDFROOT} MACHINENAME=${ASGS_MACHINE_NAME}"
 
 if [ ! -d ${ADCIRCBASE} ]; then
   if [ "$INTERACTIVE" == "yes" ]; then
@@ -168,6 +170,7 @@ if [ -d "$ADCIRCBASE/.git" ]; then
 fi
 
 ADCIRCDIR=${ADCIRCBASE}/work
+SWANDIR=${ADCIRCBASE}/swan
 # final check to make sure it looks like the expected ADCIRC source
 if [ ! -d "$ADCIRCDIR" ]; then
   echo "$ADCIRCDIR is missing the './work' directory. Exiting install."
@@ -179,6 +182,8 @@ if [ "$INTERACTIVE" = "yes" ]; then
   echo
   echo "About to build ADCIRC in $ADCIRCDIR with the following command:"
   echo
+  echo "cd $SWANDIR && \\"
+  echo "   $SWAN_MAKE_CMD && \\"
   echo "cd $ADCIRCDIR && \\"
   echo "   $ADCIRC_MAKE_CMD"
   echo
@@ -195,7 +200,9 @@ if [ "$INTERACTIVE" = "yes" ]; then
 fi
 
 # attempt to build
-cd $ADCIRCDIR
+cd $SWANDIR    && \
+$SWAN_MAKE_CMD && \
+cd $ADCIRCDIR  && \
 $ADCIRC_MAKE_CMD
 
 # catch failed exit status, for both interactive and initial asgs-brew.pl build
@@ -215,14 +222,17 @@ echo 'export ASGS_MACHINE_NAME='$ASGS_MACHINE_NAME      >> $ADCIRC_META_FILE
 echo 'export NETCDFHOME='$NETCDFHOME                    >> $ADCIRC_META_FILE
 echo 'export ADCIRCBASE='$ADCIRCBASE                    >> $ADCIRC_META_FILE
 echo 'export ADCIRCDIR='$ADCIRCDIR                      >> $ADCIRC_META_FILE
+echo "export SWANDIR='$SWANDIR'"                        >> $ADCIRC_META_FILE
 echo 'export ADCIRC_COMPILER='$ADCIRC_COMPILER          >> $ADCIRC_META_FILE
 echo 'export ADCIRC_GIT_BRANCH='$ADCIRC_GIT_BRANCH      >> $ADCIRC_META_FILE
 echo 'export ADCIRC_GIT_URL='$ADCIRC_GIT_URL            >> $ADCIRC_META_FILE
 echo 'export ADCIRC_GIT_REPO='$ADCIRC_GIT_REPO          >> $ADCIRC_META_FILE
 echo 'export ASGS_MAKEJOBS='$ASGS_MAKEJOBS              >> $ADCIRC_META_FILE
 echo "export ADCIRC_MAKE_CMD='$ADCIRC_MAKE_CMD'"        >> $ADCIRC_META_FILE
+echo "export SWAN_MAKE_CMD='$SWAN_MAKE_CMD'"            >> $ADCIRC_META_FILE
 echo "export ADCIRC_PROFILE_NAME=$ADCIRC_PROFILE_NAME"  >> $ADCIRC_META_FILE
 echo "export ADCIRC_BINS='$ADCIRC_BINS'"                >> $ADCIRC_META_FILE
+echo "export SWAN_BINS='$SWAN_BINS'"                    >> $ADCIRC_META_FILE
 
 if [ "$INTERACTIVE" == "yes" ]; then
   echo


### PR DESCRIPTION
Issue #299: This change bring support for SWAN on par with ADCIRC
and is fully supported in the ADCIRC build profile mechanism in
asgsh. When an ADCIRC profile is loaded, all binaries are now
available via path (e.g., `which unhcat.exe` works, etc).

Issue #312: Discovered and fixed typo when the install directory
was getting added to PATH in asgs-brew.pl. This affected many
binaries being available in PATH - including ncdump, adcirc, adcprep,
padswan, etc.

Resolves #299.

Resolves #312.