### PR TITLE
fixes and improvements utilities used to subset results and interpolate at stations 

### DIFF
--- a/output/asgsio.f90
+++ b/output/asgsio.f90
@@ -997,6 +997,7 @@ select case(fn%dataFileCategory)
 case(MINMAX,STATION,DOMAIN)
    fn%fun = availableUnitNumber()
    call allMessage(INFO,'Checking number of nodes in data file.') 
+   lineNum = 1
    call openFileForRead(fn%fun, trim(fn%dataFileName), errorIO)
    read(fn%fun,*,end=246,err=248,iostat=errorio) fn%agridRunIDRunDesLine
    lineNum=lineNum+1
@@ -1843,6 +1844,7 @@ integer :: nc_count(2)
 integer :: nc_start3D(3)
 integer :: nc_count3D(3)
 integer :: errorIO ! i/o error flag
+character(len=10000) :: line ! used in debugging
 !
 if ( (f%dataFileFormat.eq.NETCDFG).and.(s.gt.f%nSnaps) ) then 
    call allMessage(INFO,'All datasets have been read.')
@@ -1880,6 +1882,11 @@ case(ASCII,ASCIIG)
       else
          ! non-sparse and non-fort.88 
          if (f%dataFileCategory.ne.INITRIVER) then
+         
+                  ! jgfdebug
+         !read(unit=f%fun,fmt=*,end=246,err=248,iostat=errorio) line
+         !write(*,*) trim(adjustl(line))
+         
             read(f%fun,fmt=*,end=246,err=248,iostat=errorio) SnapR, SnapI
             numNodesNonDefault = f%numValuesPerDataSet
             l = l + 1
@@ -1906,6 +1913,11 @@ case(ASCII,ASCIIG)
    else
       ! sparse or full ascii real numbers
       do n=1,numNodesNonDefault
+          
+         ! jgfdebug
+         !read(unit=f%fun,fmt=*,end=246,err=248,iostat=errorio) line
+         !write(*,*) trim(adjustl(line))
+         
          read(unit=f%fun,fmt=*,end=246,err=248,iostat=errorio) h, (dtemp(c), c=1,f%irtype)
          l = l + 1
          !if (allocated(f%rdata).eqv..true.) then
@@ -1992,6 +2004,9 @@ integer :: ncStartMinMax(1)
 select case(f%dataFileFormat)
 case(ASCII,SPARSE_ASCII,ASCIIG)
 
+   !jgfdebug 
+
+
    if (f%is3D.eqv..true.) then
       !
       ! WRITE 3D DATA
@@ -2065,6 +2080,8 @@ case(ASCII,SPARSE_ASCII,ASCIIG)
          ! 
             write(f%fun,2120) snapr, snapi
             ! write full dataset
+            !jgfdebug
+            !write(*,*) f%numValuesPerDataset
             if (allocated(f%rdata).eqv..true.) then
                do h=1,f%numValuesPerDataset       ! came from ascii
                   write(f%fun,2453) h, (f%rdata(c,h), c=1,f%irtype)

--- a/output/pullStationTimeSeries.f90
+++ b/output/pullStationTimeSeries.f90
@@ -2,7 +2,7 @@
 ! pullStationTimeSeries.f90: Create ADCIRC ascii elevation station
 ! file (fort.61) from ADCIRC fort.63 file.
 !------------------------------------------------------------------
-! Copyright(C) 2015--2018 Jason Fleming
+! Copyright(C) 2015--2020 Jason Fleming
 !
 ! This file is part of the ADCIRC Surge Guidance System (ASGS).
 !
@@ -33,34 +33,44 @@ type(meshNetCDF_t) :: n
 character(len=1024) :: dataSetHeaderLine
 character(len=1024) :: headerLineOne
 character(len=1024) :: stationFileName ! name of file containing list of stations
+character(len=1024) :: nodeFileName    ! name of file containing list of node numbers
 type(fileMetaData_t) :: ft ! full domain time series data file to pull from
 type(fileMetaData_t) :: fs ! time series data file at stations
 real(8), allocatable :: adcirc_data(:,:) ! (np,irtype)
 real(8) :: stationVal, temp1, temp2
 integer :: numStations
+integer :: numNodeStations ! nodes where values should be output
+integer, allocatable :: nodeStations(:) ! node numbers where values should be reported
+logical, allocatable :: isNodeStationInMesh(:) ! in case node number is outside mesh range
 integer :: nc_start(2)
 integer :: nc_count(2)
 integer :: sbtUnit
 integer :: sfUnit
+integer :: nfUnit
 integer :: swUnit
 integer :: snapi
 real(8) :: snapr
 integer :: numNodesNonDefault
-integer :: i, j, node, ss, s
+integer :: i, j, node, ds, s, k
 integer :: errorIO
 logical :: zeroIndex ! true if stations should be numbered starting at zero 
 integer :: stationStart ! station index to start on
 integer :: stationEnd   ! station index to end on
+logical :: useGivenNodeNumber ! .true. if given node numbers should be used in first column of output
 
 ! initializations
 call initLogging(availableUnitNumber(),'pullStationTimeSeries.f90')
 m%meshFileName = 'fort.14'
-stationFileName = 'stations.txt'
+stationFileName = 'null'  ! e.g., stations.txt
+nodeFileName = 'null'     ! e.g., nodes.txt
+numStations = 0
+numNodeStations = 0
 fs%dataFileName = 'stations_timeseries.txt'
 fs%dataFileFormat = ASCIIG
 ft%dataFileFormat = ASCIIG
 dataSetHeaderLine = "-99999.0 -99999"
 zeroIndex = .false.
+useGivenNodeNumber = .false.
 
 argcount = command_argument_count() ! count up command line options
 if (argcount.gt.0) then
@@ -90,6 +100,14 @@ if (argcount.gt.0) then
          call getarg(i, cmdlinearg)
          write(6,'(99(a))') "INFO: Processing ",trim(cmdlineopt)," ",trim(cmdlinearg),"."
          stationFileName = trim(cmdlinearg)
+      case("--nodefile")
+         i = i + 1
+         call getarg(i, cmdlinearg)
+         write(6,'(99(a))') "INFO: Processing ",trim(cmdlineopt)," ",trim(cmdlinearg),"."
+         nodeFileName = trim(cmdlinearg)
+      case("--use-given-node-number")
+         write(6,'(99(a))') "INFO: processing ",trim(cmdlineopt),"."
+         useGivenNodeNumber = .true.         
       case("--outputfile")
          i = i + 1
          call getarg(i, cmdlinearg)
@@ -108,32 +126,6 @@ else
    READ(*,*) stationFileName
 end if    
 !
-!  count the number of stations
-sfUnit = availableUnitNumber()
-call openFileForRead(sfUnit, stationFileName, errorIO)
-numStations = 0
-do
-   read(sfUnit,*,end=7)
-   numStations = numStations + 1
-end do
-7 write(6,'(a,i0,a,a)') 'INFO: There are ',numStations,' station(s) in ',trim(stationFileName),'.'
-rewind(sfUnit)
-stationStart = 1
-stationEnd = numStations
-if (zeroIndex.eqv..true.) then
-   stationStart = 0
-   stationEnd = numStations - 1 
-endif
-allocate(stations(stationStart:stationEnd))
-!
-! read station file
-write(6,'(a)') 'INFO: Reading station file.'
-do i=stationStart, stationEnd
-   read(sfUnit,*) stations(i)%lon, stations(i)%lat
-end do
-close(sfUnit)
-write(6,'(a)') 'INFO: Finished reading station file.'
-!
 ! read in the mesh
 if ( ft%dataFileFormat.eq.NETCDFG ) then
    m%meshFileName = ft%dataFileName
@@ -141,6 +133,72 @@ if ( ft%dataFileFormat.eq.NETCDFG ) then
    call readMeshNetCDF(m, n)
 else
    call read14(m)
+endif
+!
+!  count the number of stations
+if ( trim(adjustl(stationFileName)).ne.'null' ) then
+   sfUnit = availableUnitNumber()
+   call openFileForRead(sfUnit, stationFileName, errorIO)
+   numStations = 0
+   do
+      read(sfUnit,*,end=7)
+      numStations = numStations + 1
+   end do
+   7 write(6,'(a,i0,a,a,a)') 'INFO: There are ',numStations,' station(s) in ',trim(adjustl(stationFileName)), '.'
+   rewind(sfUnit)
+   stationStart = 1
+   stationEnd = numStations
+   if (zeroIndex.eqv..true.) then
+      stationStart = 0
+      stationEnd = numStations - 1 
+   endif
+   allocate(stations(stationStart:stationEnd))
+   !
+   ! read station file
+   write(6,'(a)') 'INFO: Reading station file.'
+   do i=stationStart, stationEnd
+      read(sfUnit,*) stations(i)%lon, stations(i)%lat
+   end do
+   close(sfUnit)
+   write(6,'(a)') 'INFO: Finished reading station file.'
+endif
+!
+!  count the number of node stations (if any)
+if ( trim(adjustl(nodeFileName)).ne.'null' ) then
+   nfUnit = availableUnitNumber()
+   call openFileForRead(nfUnit, nodeFileName, errorIO)
+   numNodeStations = 0
+   do
+      read(nfUnit,*,end=8)
+      numNodeStations = numNodeStations + 1
+   end do
+   8 write(6,'(a,i0,a,a,a)') 'INFO: There are ',numNodeStations,' node(s) in ',trim(nodeFileName),'.'
+   rewind(nfUnit)
+   allocate(nodeStations(numNodeStations))
+   allocate(isNodeStationInMesh(numNodeStations))   
+   isNodeStationInMesh(:) = .true. ! most likely case
+   !
+   ! read node station file for the node numbers 
+   write(6,'(a)') 'INFO: Reading node file.'
+   do i=1, numNodeStations
+      read(nfUnit,*) nodeStations(i)
+   end do
+   close(nfUnit)
+   write(6,'(a)') 'INFO: Finished reading node file.'
+   write(6,'(a)') 'INFO: Checking list of nodes against mesh node number range.'
+   do i=1,numNodeStations
+      if ( nodeStations(i).lt.1 .or. nodeStations(i).gt.m%np ) then
+         write(6,'(a,i0,a)') 'WARNING: Node ',nodeStations(i),' was not found in the mesh.'
+         isNodeStationInMesh(i)=.false. ! use this later to avoid lookup errors
+      endif
+   end do
+   write(6,'(a)') 'INFO: Finished checking list of nodes against mesh.'
+endif
+!
+! bomb out if there are no locations to report data on
+if ( numStations.eq.0 .and. numNodeStations.eq.0 ) then
+   write(6,'(a)') 'WARNING: There are no stations or nodes. Exiting.'
+   stop
 endif
 ! 
 ! grab memory for holding a single data set for 1 or 2 component data
@@ -150,12 +208,14 @@ allocate(adcirc_data(m%np,2))
 !
 ! loop over the stations, find the element that contains each station,
 ! and compute the interpolation weights
-write(6,'(a,i0,a)') 'INFO: Finding element containing each station and computing interpolation weights for ',numStations,' station(s).'
-do s=stationStart, stationEnd
-   write(6,'(i0,1x)',advance='no') s    ! update progress bar
-   stations(s)%elementFound = .false.
-   call computeStationWeights(stations(s), m)
-end do
+if ( numStations.ne.0 ) then
+   write(6,'(a,i0,a)') 'INFO: Finding element containing each station and computing interpolation weights for ',numStations,' station(s).'
+   do s=stationStart, stationEnd
+      write(6,'(i0,1x)',advance='no') s    ! update progress bar
+      stations(s)%elementFound = .false.
+      call computeStationWeights(stations(s), m)
+   end do
+endif
 !
 ! open the text file for writing time series data
 fs%fun = availableUnitNumber()
@@ -172,12 +232,12 @@ case(ASCIIG)
    read(ft%fun,'(a1024)') headerLineOne
    write(fs%fun,*) trim(adjustl(headerLineOne))
    read(ft%fun,*) ft%nSnaps, ft%numValuesPerDataset, ft%time_increment, ft%nspool, ft%irtype
-   write(fs%fun,'(i0,1x,i0,1x,f15.7,1x,i0,1x,i0)') ft%nSnaps, numStations, ft%time_increment, ft%nspool, ft%irtype
-   SS=1  ! jgf: initialize the dataset counter
+   write(fs%fun,'(i0,1x,i0,1x,f15.7,1x,i0,1x,i0)') ft%nSnaps, (numStations+numNodeStations), ft%time_increment, ft%nspool, ft%irtype
+   ds=1  ! jgf: initialize the dataset counter
    !
    ! jgf: loop until we run out of data
    do    
-      write(6,'(i0,1x)',advance='no') ss    ! update progress bar
+      write(6,'(i0,1x)',advance='no') ds    ! update progress bar
       read(ft%fun,'(a80)',END=123,ERR=123) dataSetHeaderLine
       ! jgfdebug 
       ! write(*,*) 'dataSetHeaderLine is ',trim(dataSetHeaderLine)
@@ -202,11 +262,22 @@ case(ASCIIG)
             adcirc_data(j,2) = temp2
          end do     
       end select
+      ! add dataset header
       write(fs%fun,*) snapR, snapI
-      do s=stationStart, stationEnd
-         call writeStationValue(adcirc_data, m, numNodesNonDefault, ft%irtype, stations(s), s, fs%fun)
-      end do
-      ss = ss + 1
+      s=0
+      ! write station values (if any) for this dataset
+      if ( numStations.ne.0 ) then
+         do s=stationStart, stationEnd
+            call writeStationValue(adcirc_data, m, numNodesNonDefault, ft%irtype, stations(s), s, fs%fun)
+         end do
+      endif
+      ! write nodal values (if any) for this dataset
+      if ( numNodeStations.ne.0 ) then
+         do k=1, numNodeStations
+            call writeNodalValue(adcirc_data, m%np, ft%irtype, nodeStations(k), isNodeStationInMesh(k), (k+s), useGivenNodeNumber, fs%fun)
+         end do
+      endif              
+      ds = ds + 1
    end do
 123 close(ft%fun) ! jgf: When we've run out of datasets in the current file,
                   ! we jump to here.     
@@ -215,7 +286,7 @@ case(NETCDFG)
    headerLineOne = trim(rundes) // ' ' // trim(runid) // ' ' // trim(m%agrid)
    snapR = ft%time_increment
    write(fs%fun,*) trim(adjustl(headerLineOne))
-   write(fs%fun,'(i0,1x,i0,1x,f15.7,1x,i0,1x,i0)') ft%nSnaps, numStations, ft%time_increment, ft%nspool, ft%irtype
+   write(fs%fun,'(i0,1x,i0,1x,f15.7,1x,i0,1x,i0)') ft%nSnaps, (numStations+numNodeStations), ft%time_increment, ft%nspool, ft%irtype
 
    ! open the netcdf file
    call check(nf90_open(trim(ft%dataFileName), NF90_NOWRITE, ft%nc_id))   
@@ -236,10 +307,20 @@ case(NETCDFG)
          ! get data
          call check(nf90_get_var(ft%nc_id,ft%ncds(j)%nc_varID,adcirc_data(:,j),nc_start,nc_count))
       end do
-      write(fs%fun,*) ft%timesec(i), ft%it(i)      
-      do s=stationStart, stationEnd   
-         call writeStationValue(adcirc_data, m, ft%numValuesPerDataSet, ft%irtype, stations(s), s, fs%fun)
-      end do
+      write(fs%fun,*) ft%timesec(i), ft%it(i)
+      s=0
+      ! write station values (if any) for this dataset
+      if ( numStations.ne.0 ) then            
+         do s=stationStart, stationEnd   
+            call writeStationValue(adcirc_data, m, ft%numValuesPerDataSet, ft%irtype, stations(s), s, fs%fun)
+         end do
+      endif
+      ! write nodal values (if any) for this dataset
+      if ( numNodeStations.ne.0 ) then
+         do k=1, numNodeStations
+            call writeNodalValue(adcirc_data, m%np, ft%irtype, nodeStations(k), isNodeStationInMesh(k), (k+s), useGivenNodeNumber, fs%fun)
+         end do
+      endif              
    end do
    close(fs%fun)
    if (ft%dataFileCategory.eq.MINMAX) then
@@ -255,10 +336,20 @@ case(NETCDFG)
       call check(nf90_inq_varid(ft%nc_id, trim('time_of_' // adjustl(ft%ncds(1)%varNameNetCDF)), ft%ncds(1)%nc_varid))
       call check(nf90_get_var(ft%nc_id,ft%ncds(j)%nc_varID,adcirc_data(:,1),nc_start,nc_count))     
       write(fs%fun,*) ft%timesec(1), ft%it(1)      
-      do s=stationStart, stationEnd   
-         call writeStationValue(adcirc_data, m, ft%numValuesPerDataset, ft%irtype, stations(s), s, fs%fun)
-      end do
+      s=0
+      ! write station values (if any) for this dataset
+      if ( numStations.ne.0 ) then            
+         do s=stationStart, stationEnd   
+            call writeStationValue(adcirc_data, m, ft%numValuesPerDataset, ft%irtype, stations(s), s, fs%fun)
+         end do
+      endif
       close(fs%fun)
+      ! write nodal values (if any) for this dataset
+      if ( numNodeStations.ne.0 ) then
+         do k=1, numNodeStations
+            call writeNodalValue(adcirc_data, m%np, ft%irtype, nodeStations(k), isNodeStationInMesh(k), (k+s), useGivenNodeNumber, fs%fun)
+         end do
+      endif                    
    endif
    call check(nf90_close(ft%nc_id))
 case default
@@ -269,34 +360,54 @@ close(61)
 !
 ! write the station weights to a text file in fort.61 format 
 ! for reference or troubleshooting
-swUnit = availableUnitNumber()
-open(unit=swUnit,file='station_weights.61',status='replace',action='write')
-write(swUnit,*) trim(adjustl(headerLineOne))
-write(swUnit,'(i0,1x,i0,1x,f15.7,1x,i0,1x,i0)') ft%nSnaps, numStations, ft%time_increment, ft%nspool, 3
-write(swUnit,*) trim(adjustl(dataSetHeaderLine))
-do s=stationStart,stationEnd 
-   write(swUnit,'(i10,2x,3(f15.7,3x))') s, (stations(s)%w(i),i=1,3)
-end do
-close(swUnit)
-write(6,'(/,a)') 'INFO: Finished finding element(s) and computing interpolation weights.'
+! write station values (if any) for this dataset
+if ( numStations.ne.0 ) then
+   swUnit = availableUnitNumber()
+   open(unit=swUnit,file='station_weights.61',status='replace',action='write')
+   write(swUnit,*) trim(adjustl(headerLineOne))
+   write(swUnit,'(i0,1x,i0,1x,f15.7,1x,i0,1x,i0)') ft%nSnaps, numStations, ft%time_increment, ft%nspool, 3
+   write(swUnit,*) trim(adjustl(dataSetHeaderLine))
+   do s=stationStart,stationEnd 
+      write(swUnit,'(i10,2x,3(f15.7,3x))') s, (stations(s)%w(i),i=1,3)
+   end do
+   close(swUnit)
+   write(6,'(/,a)') 'INFO: Finished finding element(s) and computing interpolation weights.'
+endif
 !
 ! use station weights to interpolate bathy/topo at station locations
 ! and write out bathy/topo elevations in fort.61 format
 sbtUnit = availableUnitNumber()
 open(unit=sbtUnit,file='station_bathytopo.61',status='replace',action='write')
 write(sbtUnit,*) trim(adjustl(headerLineOne))
-write(sbtUnit,'(i0,1x,i0,1x,f15.7,1x,i0,1x,i0)') ft%nSnaps, numStations, ft%time_increment, ft%nspool, 1
+write(sbtUnit,'(i0,1x,i0,1x,f15.7,1x,i0,1x,i0)') ft%nSnaps, (numStations+numNodeStations), ft%time_increment, ft%nspool, 1
 write(sbtUnit,*) trim(adjustl(dataSetHeaderLine))
-do s=stationStart,stationEnd
-   if (stations(s)%elementIndex.eq.0) then
-      stationVal = -99999.0
-   else
-      stationVal = m%xyd(3,m%nm(stations(s)%elementIndex,1)) * stations(s)%w(1) &
-                 + m%xyd(3,m%nm(stations(s)%elementIndex,2)) * stations(s)%w(2) &
-                 + m%xyd(3,m%nm(stations(s)%elementIndex,3)) * stations(s)%w(3) 
-   endif
-   write(sbtUnit,'(i10,2x,e17.10)') s, stationVal
-end do
+s=0
+if ( numStations.ne.0 ) then
+   do s=stationStart,stationEnd
+      if (stations(s)%elementIndex.eq.0) then
+         stationVal = -99999.0
+      else
+         stationVal = m%xyd(3,m%nm(stations(s)%elementIndex,1)) * stations(s)%w(1) &
+                    + m%xyd(3,m%nm(stations(s)%elementIndex,2)) * stations(s)%w(2) &
+                    + m%xyd(3,m%nm(stations(s)%elementIndex,3)) * stations(s)%w(3) 
+      endif
+      write(sbtUnit,'(i10,2x,e17.10)') s, stationVal
+   end do
+endif
+if ( numNodeStations.ne.0 ) then 
+   ! write nodal values (if any) for this dataset
+   do k=1, numNodeStations
+      i = k + s ! index for first column
+      if ( useGivenNodeNumber.eqv..true. ) then
+         i = nodeStations(k)
+      endif
+      if (isNodeStationInMesh(k).eqv..true.) then 
+         write(sbtUnit,'(i10,2x,e17.10,a,i0)') i, m%xyd(3,nodeStations(k)), ' ! node ',node
+      else
+         write(sbtUnit,'(i10,2x,e17.10,a,i0,a)') i, -99999.0, ' ! warning: node ',node,' was not found in the mesh. '               
+      endif
+   end do
+endif
 close(sbtUnit)
 !
 write(6,'(a)') 'INFO: Wrote station values successfully.'
@@ -318,20 +429,25 @@ integer, intent(in) :: irtype ! number of vector components, 1 is scalar etc
 integer, intent(in) :: numValuesPerDataSet ! number of values in a sparse dataset?
 type(mesh_t), intent(inout) :: m 
 type(station_t), intent(in) :: station
-integer, intent(in) :: s   ! station index
+integer, intent(in) :: s    ! station index
 integer, intent(in) :: slun ! logical unit number to write to
+character(len=100) :: note  ! alert operator that station was not found
 real(8) :: stationVal, temp1, temp2
 logical :: dryNode
 integer :: i
 !
 dryNode = .false.
+note = ''
 if (station%elementIndex.ne.0) then
    do i=1,3
       if (adcirc_data(m%nm(station%elementIndex,i),1).eq.-99999) then
          dryNode = .true.
       endif
    end do
+else
+   note = ' ! warning: this station is actually outside the mesh'
 endif
+
 if (irtype.eq.1) then
    if (station%elementIndex.eq.0 .or. dryNode.eqv..true.) then
       stationVal = -99999.0
@@ -340,7 +456,7 @@ if (irtype.eq.1) then
                  + adcirc_data(m%nm(station%elementIndex,2),1) * station%w(2) &
                  + adcirc_data(m%nm(station%elementIndex,3),1) * station%w(3) 
    endif
-   write(slun,'(i10,2x,e17.10)') s, stationVal 
+   write(slun,'(i10,2x,e17.10,a)') s, stationVal, trim(note) 
 else
    if (station%elementIndex.eq.0 .or. dryNode.eqv..true.) then
       temp1 = -99999.0
@@ -353,8 +469,55 @@ else
             + adcirc_data(m%nm(station%elementIndex,2),2) * station%w(2) &
             + adcirc_data(m%nm(station%elementIndex,3),2) * station%w(3) 
    endif
-   write(slun,'(i10,2(2x,e17.10))') s, temp1, temp2
+   write(slun,'(i10,2(2x,e17.10),a)') s, temp1, temp2, trim(note)
 endif
 !-----------------------------------------------------------------------
 end subroutine writeStationValue
+!-----------------------------------------------------------------------
+
+!-----------------------------------------------------------------------
+!    S U B R O U T I N E     W R I T E   N O D A L   V A L U E 
+!-----------------------------------------------------------------------
+! Writes the time series value at the node, or -99999 if the node number
+! is not within the range 1:m%np.
+!-----------------------------------------------------------------------
+subroutine writeNodalValue(adcirc_data, nn, irtype, node, found, k, ugnn, slun)
+implicit none
+real(8), intent(in) :: adcirc_data(nn,irtype)
+integer, intent(in) :: nn     ! number of nodes in mesh
+integer, intent(in) :: irtype ! number of vector components, 1 is scalar etc
+integer, intent(in) :: node   ! the node number of interest
+logical, intent(in) :: found  ! true if node is in mesh node number range
+integer, intent(in) :: k      ! index in total list of stations+nodes
+logical, intent(in) :: ugnn   ! true if the original node number should appear in 1st column
+integer, intent(in) :: slun   ! i/o unit number to write to
+
+integer :: i                  ! 1st column index
+
+i = k
+if (ugnn.eqv..true.) then
+   i = node
+endif
+
+if (irtype.eq.1) then
+   if (found.eqv..true.) then 
+      write(slun,'(i10,2x,e17.10,a,i0)') &
+         i, adcirc_data(node,1), ' ! node ',node
+   else
+      write(slun,'(i10,2x,e17.10,a,i0,a)') &
+         i, -99999.0, ' ! warning: node ',node,' was not found in the mesh. '               
+   endif
+endif
+
+if (irtype.eq.2) then
+   if (found.eqv..true.) then 
+      write(slun,'(i10,2(2x,e17.10),a,i0)') &
+         i, adcirc_data(node,1), adcirc_data(node,2),' ! node ',node
+   else
+      write(slun,'(i10,2(2x,e17.10),a,i0,a)') &
+         i, -99999.0, -99999.0,' ! warning: node ',node,' was not found in the mesh. '               
+   endif
+endif
+!-----------------------------------------------------------------------
+end subroutine writeNodalValue
 !-----------------------------------------------------------------------

--- a/output/resultScope.f90
+++ b/output/resultScope.f90
@@ -106,6 +106,7 @@ fd%dataFileFormat = ASCII
 rd%dataFileFormat = ASCII
 meshonly = .false.
 dataFileBase = "null"
+fd%defaultFileName = "null"
 !
 call initLogging(availableUnitNumber(),'resultScope.f90')
 !
@@ -450,22 +451,31 @@ if (trim(fd%defaultFileName).eq.'fort.13') then
    call writeNodalAttributesFile(rna)   
    stop
 else
-   call allMessage(INFO,'Not a nodal attributes file:'//trim(fd%defaultFileName))
-   
+   if ( trim(adjustl(fd%defaultFileName)).ne.'null' ) then
+      call allMessage(INFO,'Not a nodal attributes file: '//trim(adjustl(fd%defaultFileName)))  
+   endif
 endif
 !
 ! set up subdomain result file
+if (rd%isElemental.eqv..true.) then
+   rd%numValuesPerDataset = rm%ne
+else
+   rd%numValuesPerDataset = rm%np
+endif 
+rd%irtype = fd%irtype
+!
 select case(rd%dataFileFormat) 
 !
 ! result file (subdomain) in ascii format
 case(ASCII)
+
    ! open the subdomain ascii adcirc file that will hold the data and
    ! write the header
    rd%dataFileName = 'sub-' // trim(resultShape) // '_' // trim(fd%dataFileName) 
    rd%fun = availableUnitNumber()
    open(rd%fun,file=trim(rd%dataFileName),status='replace',action='write')
    ! write header info
-   write(rd%fun,'(a)') trim(rm%agrid) // trim(rd%dataFileName) // ' ' // trim(dataFileCommentLine)
+   write(rd%fun,'(a)') trim(rm%agrid) // trim(rd%dataFileName) // ' ' // trim(fd%agridRunIDRunDesLine)
    ! write the header data to the resultshape file
    write(rd%fun,1010) fd%nSnaps, rd%numValuesPerDataSet, fd%time_increment, fd%nspool, fd%irtype
 !
@@ -568,17 +578,28 @@ case(NETCDFG)
          rd%ncds(i)%mapping => sub2fullNodes
       endif
    end do 
-case(ASCIIG) 
+case(ASCII) 
    ! establish mapping from subdomain to fulldomain
    if (rd%isElemental.eqv..true.) then
       rd%mapping => sub2fullElements
    else
       rd%mapping => sub2fullNodes
-   endif
+   endif 
 case default
    ! should be unreacable
    call allMessage(ERROR,'Only NETCDF and ASCII full domain file formats are supported.')
 end select  
+!
+! open the fulldomain ascii data file for reading
+if ( fd%dataFileFormat.eq.ASCII ) then
+   lineNum = 1
+   fd%fun = availableUnitNumber()
+   call openFileForRead(fd%fun,fd%dataFileName,errorIO)
+   read(fd%fun,*,end=246,err=248,iostat=errorio) junkc  ! comment line
+   lineNum=lineNum+1
+   read(fd%fun,*,end=246,err=248,iostat=errorio) junkc  ! nSnaps etc
+   lineNum=lineNum+1
+endif
 !
 !
 !  R E A D   I N   F U L L D O M A I N   D A T A   
@@ -593,17 +614,21 @@ DO   ! jgf: loop until we run out of data (can't trust the nSnaps at top of asci
    !  
 
 !subroutine readOneDataSet(f, m, s, l, snapr, snapi)
-
+   
+   ! jgfdebug
+   !write(*,*) 'call readOneDataset(fd, fm, ss, lineNum, snapr, snapi)'
+   
    call readOneDataset(fd, fm, ss, lineNum, snapr, snapi)
+   !write(*,*) 'call readOneDataset(fd, fm, ss, lineNum, snapr, snapi)'
    call appendR1D(timesec, snapr)
    call appendI1D(it, snapi)
-   call allMessage(INFO,"read one data file") !jgfdebug
+   !call allMessage(INFO,"read one data file") !jgfdebug
    !
    !  P O P U L A T E   R E S U L T   A R R A Y ( S ) 
    !        F O R   T H I S   S I N G L E   D A T A S E T
    ! 
    ! ASCII FULLDOMAIN FILE and ASCII SUBDOMAIN FILE
-   if ( (fd%dataFileFormat.eq.ASCIIG).and.(rd%dataFileFormat.eq.ASCIIG) ) then
+   if ( (fd%dataFileFormat.eq.ASCII).and.(rd%dataFileFormat.eq.ASCII) ) then
       ! map 3D real data  ascii->ascii
       if ( (fm%is3D.eqv..true.).and.(fd%is3D.eqv..true.) ) then
          do h=1,rd%numValuesPerDataSet
@@ -703,6 +728,10 @@ DO   ! jgf: loop until we run out of data (can't trust the nSnaps at top of asci
    !   W R I T E   O U T   O N E   R E S U L T   D A T A S E T
    !  
    !call readOneDataset(fd, fm, ss, lineNum, snapr, snapi)   
+
+            !jgfdebug
+            !write(*,*) rd%numValuesPerDataset
+
    call writeOneDataSet(rd, rm, ss, lineNum, snapr, snapi)
    !
    write(6,advance='no',fmt='(i6)') SS

--- a/output/station_transpose.pl
+++ b/output/station_transpose.pl
@@ -8,7 +8,7 @@
 # different stations and the rows represent time. 
 #
 #----------------------------------------------------------------
-# Copyright(C) 2009--2018 Jason Fleming
+# Copyright(C) 2009--2020 Jason Fleming
 #
 # This file is part of the ADCIRC Surge Guidance System (ASGS).
 #
@@ -40,38 +40,42 @@ use Math::Trig;
 sub stderrMessage($$);
 #
 our %properties; # key/value pairs _read from_ properties files
-our $runproperties = "run.properties"; # full path to metadata file from ASGS 
+our $runproperties = "null"; # full path to run.properties metadata file from ASGS 
 my $pi = 3.14159265;
 my $g = 9.81;
 my $density = 1000.0;
+my $s = 0;                  # index of the station in the station list or dataset
 my $averagingperiod = "10min";
 my $fileToTranspose = "null"; # type of file to transpose 
-my $controlfile = "null"; # full path name of control file (parsed to obtain list of stations)
-my $stationfile = "null"; # full path name of station file (list of stations) in standard format 
-my $datafile = "null";    # full path name to file containing data at each station 
-my $format = "space"; # column separator in transposed file (space or comma)
+my $controlfile = "null";  # full path name of control file (parsed to obtain list of stations)
+my $stationfile = "null";  # full path name of station file (list of stations) in standard format 
+my $datafile = "null";     # full path name to file containing data at each station 
+my $drymaskfile = "null"; # elevation station file used to mask dry areas in other file types
+my $format = "space";      # column separator in transposed file (space or comma)
 my $separator = " "; 
-my $vectorOutput = "raw"; # "raw" (for east and north values), "compassdirection" or "trigdirection" (degrees) along with magnitude 
+my $vectorOutput = "raw";  # "raw" (for east and north values), "compassdegrees" or "trigdegrees" along with magnitude 
 my $coldstartdate = "null"; # yyyymmddhh24 when the simulation was coldstarted
 my $gmtoffset=-5; # number of hours between gmt and local time
 my $timezone="GMT"; # time zone designation to be placed on graphs
 my $units = "null"; # output units, english or si
-my $stationlabel = "full"; # how to parse the station label from fort.15
+my $stationlabel = "full";  # how to parse the station label from fort.15
 # on command line, use 
 # --stationlabel full
-# uses the entire line from fort.15 and copies it to the header in the 
-# transposed file
+#    uses the entire line from fort.15 and copies it to the header in the 
+#    transposed file
 # --stationlabel std
-# assumes that the fort.15 station metadata are in the standard adcirc
-# metadata format and that the stations will be labeled with the ID 
-# and description
+#    assumes that the fort.15 station metadata are in the standard adcirc
+#    metadata format and that the stations will be labeled with the ID 
+#    and description
 # --stationlabel 'after exclamation point' 
-# to use everything after the first exclamation point as the station label
+#    to use everything after the first exclamation point as the station label
 # --stationlabel betweenbangs
-# if the station comment line has the station ID between two exclamation 
-# points and only the station ID should be used on the plots; e.g., the
-# station line in the fort.15 looks like this
-# -88.55779 30.43825 ! SSS-MS-JAC-051WL ! storm tide, water level Jackson Mississippi hwm: 5.42 ft NAVD88 at 16:30:28 8/29/2012 GMT
+#    if the station comment line has the station ID between two exclamation 
+#    points and only the station ID should be used on the plots; e.g., the
+#    station line in the fort.15 looks like this
+#    -88.55779 30.43825 ! SSS-MS-JAC-051WL ! storm tide, water level Jackson Mississippi hwm: 5.42 ft NAVD88 at 16:30:28 8/29/2012 GMT
+# --stationlabel raw 
+#    uses the station number from the fort.61 file 
 my $firstBang;  # where first "!" appears in station metadata in fort.15 
 my $secondBang; # where second "!" appears in station metadata in fort.15  
 my $thirdBang;  # where third "!" appears in station metadata in fort.15 
@@ -112,6 +116,7 @@ GetOptions(
            "filetotranspose=s" => \$fileToTranspose,
            "controlfile=s" => \$controlfile,
            "stationfile=s" => \$stationfile,
+           "drymaskfile=s" => \$drymaskfile,
            "datafile=s" => \$datafile,
            "format=s" => \$format,
            "vectoroutput=s" => \$vectorOutput,
@@ -143,11 +148,6 @@ if ( is_member($fileToTranspose,@supported_minmax_files) ) {
    $minmax = 1;
 }
 #
-# read the run.properties file if it was specified
-if ( -e $runproperties ) {
-   &loadProperties;
-}
-#
 # if we are producing a csv file
 if ( $format eq "comma" ) {
    $separator = ",";
@@ -155,6 +155,10 @@ if ( $format eq "comma" ) {
 #
 # if coldstartdate was supplied on the command line, use that
 if ( $runproperties ne "null" ) {
+   # read the run.properties file if it was specified
+   if ( -e $runproperties ) {
+      &loadProperties;
+   }
    # open run.properties file and read the coldstartdate from there
    $coldstartdate = $properties{"config.adcirc.time.coldstartdate"};
    if ( $coldstartdate ) {
@@ -336,8 +340,10 @@ for ( my $i=0; $i<$num_sta; $i++ ) {
       $stationPlotLabels[$i] = $sta_coords[$i];
    }
    # remove leading and trailing whitespaces
-   $stationPlotLabels[$i] =~ s/^\s+//g;
-   $stationPlotLabels[$i] =~ s/\s+$//g; 
+   unless ( $stationlabel eq "raw" ) {
+      $stationPlotLabels[$i] =~ s/^\s+//g;
+      $stationPlotLabels[$i] =~ s/\s+$//g; 
+   }
 }
 #
 # jgfdebug
@@ -349,6 +355,7 @@ my $filename;
 my $fileExtension;
 my $total_stations = 0;
 my @station_val = ();
+my @stationNumber = ();
 my @vector_tuple_1 = ();
 my @vector_tuple_2 = ();
 my $header;       # start on comment on first line of reformatted file
@@ -395,7 +402,16 @@ if ( $format eq "comma" ) {
 unless (open(DATAFILE,"<$datafile")) {
    &stderrMessage("ERROR","Could not open data file $datafile for reading: $!.");
    die;
-} 
+}
+# open the dry mask file (assumed to be in fort.61 station file format)
+# for use in adding missing (-99999) values in dry areas for non-elevation
+# data
+if ( $drymaskfile ne "null" ) {
+   unless (open(DRYMASKFILE,"<$drymaskfile")) {
+     &stderrMessage("ERROR","Could not open data file $drymaskfile for reading: $!.");
+     die;
+   }
+}
 # open up the transposed data file for writing
 my $transposeFilename = $datafile . "_transpose" . $fileExtension;
 if ( $reformattedfile ne "null" ) {
@@ -411,7 +427,20 @@ unless (open(TRANSPOSE,">$transposeFilename")) {
 my $time;
 my $num_datasets = 0;
 my $output_frequency = "null";
+$s = 0; 
 while (<DATAFILE>) {
+   my $isDry = 0;
+   my $drymaskline;
+   my @drymaskfields;
+   if ( $drymaskfile ne "null" ) { 
+      $drymaskline = <DRYMASKFILE>;
+      if ($. > 2 && ($.-3) % ($total_stations+1) != 0) {
+         @drymaskfields = split(' ',$drymaskline);
+         if ( $drymaskfields[1] == -99999 ) {
+            $isDry = 1;
+         }
+      }
+   }
    #
    # reset the multiplier before processing this line
    $multiplier = 1.0;
@@ -446,23 +475,13 @@ while (<DATAFILE>) {
             $sta_names[$i] = "Station" . $default_station_number;
          }
       }
-      # write the names of the stations on the next line according to the requested format
-      if ( $minmax == 0 && $time_minmax == 0 && $fileToTranspose ne "bathytopo" ) {
-         unless ( $coldstartdate eq "null" ) {
-            printf TRANSPOSE "#DATE" . $separator . "TIME" . $separator . "TIMEZONE" . $separator;
-         } else {
-            printf TRANSPOSE "#TIMESEC" . $separator;         
-         }
-      }
-      foreach (@stationPlotLabels) {
-          printf TRANSPOSE "\"$_\"" . $separator;
-      }
-      printf TRANSPOSE "\n";
+
       next;
    }
    #
    # there is a header line with the time, at the start of each dataset
    if ($. > 2 && ($.-3) % ($total_stations+1) == 0) {
+      $s=0;  # reinitialize the station counter 
       #
       # grab the new time (assumed to be in gmt)
       my $data_seconds = "null";
@@ -486,16 +505,19 @@ while (<DATAFILE>) {
       }
       next;
    }
-   #
+
    # this is data (not the file header or the individual dataset header)
-   my $stationNumber;
+
    if ( $fileRank eq "scalar" ) {
       my $scalar;
       # parse out the station number and the value
       m/^\s*(\d*)\s*(.*)\s*$/;
-      $stationNumber = $1;
+      $stationNumber[$s] = $1;
+      if ( $stationlabel eq "raw" ) {
+         $stationPlotLabels[$s] = $stationNumber[$s];
+      }
       # set missing value or station value
-      if ( $2 == "-0.9999900000E+05" || $2 =~/NaN/) {
+      if ( $2 == "-0.9999900000E+05" || $2 =~/NaN/ || $isDry == 1 ) {
          $scalar = -99999;
       } else {
          # apply the user-specified multiplier given on the command line
@@ -558,7 +580,7 @@ while (<DATAFILE>) {
             }
          }
       }
-      $station_val[$1-1] = $scalar;
+      $station_val[$s] = $scalar;
    } else {
       # this is vector data
       my $tuple_1;
@@ -577,23 +599,48 @@ while (<DATAFILE>) {
       }
       # parse out the station number and the two data values
       m/^\s*([^\s]*)\s*([^\s]*)\s*([^\s]*)\s*$/;
-      $stationNumber = $1;
-      if ( !($2 =~ /NaN/) && !($2 =~/Inf/) && !($2 == -99999 ) ) {
+      $stationNumber[$s] = $1;
+      if ( $stationlabel eq "raw" ) {
+         $stationPlotLabels[$s] = $stationNumber[$s];
+      }
+      if ( !($2 =~ /NaN/) && !($2 =~/Inf/) && !($2 == -99999 ) && !($isDry == 1) ) {
          $tuple_1 = $2 * $multiplier;
       } else {
          $tuple_1 = -99999;
       }
-      if ( !($3 =~ /NaN/) && !($3 =~/Inf/) && !($3 == -99999 ) ) {
+      if ( !($3 =~ /NaN/) && !($3 =~/Inf/) && !($3 == -99999 ) && !($isDry == 1) ) {
          $tuple_2 = $3 * $multiplier;
       } else {
          $tuple_2 = -99999;
       }
-      $vector_tuple_1[$1-1] = $tuple_1;
-      $vector_tuple_2[$1-1] = $tuple_2;
+      $vector_tuple_1[$s] = $tuple_1;
+      $vector_tuple_2[$s] = $tuple_2;
    }   
    #
+
    # if we have collected a complete dataset, write it now
-   if ( $stationNumber == $total_stations ) {
+
+
+   if ( $s == $total_stations-1 ) {
+
+      # if this is the first dataset to be written, write the column
+      # header with the names of the stations according to the 
+      #requested format
+      if ( $num_datasets == 0 ) {
+         if ( $minmax == 0 && $time_minmax == 0 && $fileToTranspose ne "bathytopo" ) {
+            unless ( $coldstartdate eq "null" ) {
+               printf TRANSPOSE "#DATE" . $separator . "TIME" . $separator . "TIMEZONE" . $separator;
+            } else {
+               printf TRANSPOSE "#TIMESEC" . $separator;         
+            }
+         }
+         foreach (@stationPlotLabels) {
+             printf TRANSPOSE "\"$_\"" . $separator;
+         }
+         printf TRANSPOSE "\n";
+         
+      }
+
       # first column: date/time, unless this is time_minmax file, in which
       # case, we don't need the time in the first column (there is only 
       # one row)
@@ -647,7 +694,11 @@ while (<DATAFILE>) {
                   # compute wind direction in compass degrees based on the standard that winds
                   # are reported as the direction they are coming from
                   $compassdirection = 90.0 - $trigdirection;
-
+                  if ( $compassdirection < 180.0 ) {
+                     $compassdirection += 180.0;
+                  } else { 
+                     $compassdirection -= 180.0;
+                  }
                }
                if ( $compassdirection <= 0.0 ) {
                   $compassdirection += 360.0; 
@@ -670,6 +721,7 @@ while (<DATAFILE>) {
       printf TRANSPOSE "\n";
       $num_datasets++;
    }
+   $s++;
 }
 close(TRANSPOSE);
 #


### PR DESCRIPTION
Fixed resultScope.f90 bugs so it can subset ascii fulldomain files to ascii subdomain files; fixed bugs in station_transpose.pl so that it outputs trig and compass directions correctly for current and wind; enable station_transpose.pl to read a dry mask file, aka a water surface elevation fort.61 file, to fill in -99999 for the velocity in dry nodes instead of using whatever is coming from the fort.62 file; added feature to station_transpose.pl so that it would label the column headers in the output according to the raw station number provided in the fort.61. resolves #318 #321 #322 #323 #324 