### PR TITLE
Made NHC advisory detection and parsing more robust.

### DIFF
--- a/get_atcf.pl
+++ b/get_atcf.pl
@@ -220,8 +220,12 @@ while (!$dl) {
          #stderrMessage("DEBUG","why is $why");
          my %attributes = ();
          #$attributes{'verify_SSL'} = 1;
+
          my $http = HTTP::Tiny->new(%attributes);
-         my $response = $http->get('https://' . $rsssite . '/index-at.xml');
+         my $protocol = ( $rsssite =~ m/^nhc-replay\.stormsurge\.email$/ ) ? q{http} : q{https};
+         my $url = sprintf("%s://%s/index-at.xml", $protocol, $rsssite);
+         my $response = $http->get($url);
+
          if ( $response->{status} == 599 ) { 
             stderrMessage("ERROR","Failed to download forecast/advisory.");
             printf STDERR "content: ";
@@ -296,7 +300,7 @@ while (!$dl) {
                      if ( $trigger eq "rssembedded" ) {
                         if ( $lines[$i] =~ /description/ ) {
                            $body = "";
-                           while ( $lines[$i] ne "</pre>]]></description>" ) {
+                           while ( $lines[$i] !~ m/\/pre.+\/description>/ ) {
                               $body .= $lines[$i] . "\n";
                               $i++;
                            }

--- a/nhc_advisory_bot.pl
+++ b/nhc_advisory_bot.pl
@@ -111,26 +111,19 @@ substr($atcf_line,4,2) = $storm_number_str;
 # 1500Z THU SEP 02 2004
 # July 18th TD 2. HAS CHANGED
 # NOTE NOTE NOW! 1500 UTC TUE JUL 18 2006
-if ($storm_year > 2005) {
-   @match = grep /^\d{4} .+ \d{4}$/, @{$body_ref};
-} else {
-   @match = grep /^\d{4}Z .+ \d{4}$/, @{$body_ref};
-}
+#
+@match = grep /^\d{4}Z| UTC .+ \d{4}$/, @{$body_ref};
 #
 if (@match) {
    $date_time = $match[0];
+   # "upgrade" d/t stamp to post 2005
+   $date_time =~ s/Z/ UTC/;
    chomp $date_time;
    my @vals = split( ' ', $date_time );
    $nowcast_hour = substr( $vals[0], 0, 2 );
-   if($storm_year > 2005) {
-      $nowcast_year = $vals[5];
-      $nowcast_month = $month_lookup{$vals[3]};
-      $nowcast_day = $vals[4];
-   } else {
-      $nowcast_year = $vals[4];
-      $nowcast_month = $month_lookup{$vals[2]};
-      $nowcast_day = $vals[3];
-   }
+   $nowcast_year = $vals[5];
+   $nowcast_month = $month_lookup{$vals[3]};
+   $nowcast_day = $vals[4];
    $nowcast_date_time = $nowcast_year . $nowcast_month . $nowcast_day . $nowcast_hour;
    printf STDERR "INFO: nhc_advisory_bot.pl: Time of nowcast is $nowcast_date_time\n";
    substr($atcf_line,8,10) = sprintf("%10d",$nowcast_date_time);


### PR DESCRIPTION
Issue #381: Made get_atcf.pl more robust in conjuction with many more
changes in the NHC replay scripts. Also detects "replay" server for FTP
and RSS and when detected will use "http" rather than "https". The default
for all over URLs (including the official NHC URLs) will use "https".
Extracting out the text advisory was also made more robust (end of text
advisory detection).

nhc_advisory_bot.pl was also made more robust against the difference
it data/time stamp that changed after 2005. This is so we can run
"nowified" RITA forecasts (and others from 2005 and before).

Resolves #381.