### PR TITLE
Use different backtrace option based on compiler.

### DIFF
--- a/output/logging.f90
+++ b/output/logging.f90
@@ -425,7 +425,12 @@ real(8), allocatable :: intentionalSegFault(:)
 real(8) :: triggerSegFaultIntentionallyForStackTrace
 if(ncstatus.ne.nf90_noerr)then
    write(*,'(a,a)') "ERROR: ",trim(nf90_strerror(ncstatus))
-   call backtrace
+#ifdef USE_TRACEBACKQQ
+    call tracebackqq 
+#endif
+#ifdef USE_BACKTRACE
+    call backtrace
+#endif
    triggerSegFaultIntentionallyForStackTrace = intentionalSegFault(1)
    stop 1
 endif

--- a/output/makefile
+++ b/output/makefile
@@ -50,7 +50,7 @@
 # specify compiler=gfortran on the make command line
 ifeq ($(compiler),gfortran)
    FC := gfortran
-   FFLAGS := -O2 -cpp -ffree-line-length-none
+   FFLAGS := -O2 -cpp -ffree-line-length-none -DUSE_BACKTRACE
    ifeq ($(DEBUG),full)
       FFLAGS := -cpp -ffree-line-length-none -g -O0 -fbacktrace -fbounds-check -ffpe-trap=zero,invalid,underflow,overflow,denormal -DDEBUGSEGFAULT
    endif
@@ -77,7 +77,7 @@ endif
 # due possible compiler bug. Flag not needed for ifort version 13.1.3 and later. -nld
 ifeq ($(compiler),intel)
    FC := ifort
-   FFLAGS := -cpp -shared-intel
+   FFLAGS := -cpp -shared-intel -DUSE_TRACEBACKQQ
    ifeq ($(DEBUG),trace)
       FFLAGS := -g -O0 -fpp -traceback 
    endif


### PR DESCRIPTION
Issue 393: Intel compilers were not able to find the "backtrace"
routine, rather it needs the "tracebackqq" routine - gfortran does
use the "backtrace" routine. A define flag was added and is set
when the it is detected that "ifort" is being used to compile all
of Fortran code (or most of it) in ASGS.

Resolves Issue 393.