### PR TITLE
Added support build and "profile" for ADCIRC v55release.

### DIFF
--- a/cloud/general/DOT-asgs-brew.sh
+++ b/cloud/general/DOT-asgs-brew.sh
@@ -96,22 +96,17 @@ load() {
       else
         __ADCIRC_BUILD=${2}
       fi
-      echo "loading ADCIRC build, '$__ADCIRC_BUILD' ... don't forget to save profile to persist this action."
+      echo "loading ADCIRC build, '$__ADCIRC_BUILD'."
       if [ -e "${ADCIRC_META_DIR}/${__ADCIRC_BUILD}" ]; then
           # source it
           . ${ADCIRC_META_DIR}/${__ADCIRC_BUILD}
-          echo creating symlinks to ADCIRC binaries in $ASGS_INSTALL_PATH/bin
-          for b in $ADCIRC_BINS; do
-            echo -n linking $b
-            ln -sf $ADCIRCDIR/$b $ASGS_INSTALL_PATH/bin/$b && echo ... ok
-          done          
-          echo creating symlinks to SWAN binaries in $ASGS_INSTALL_PATH/bin
-          for b in $SWAN_BINS; do
-            echo -n linking $b
-            ln -sf $SWANDIR/$b $ASGS_INSTALL_PATH/bin/$b && echo ... ok
-          done          
+          echo Prepending ADCIRCDIR and SWANDIR to PATH
+          echo + $ADCIRCDIR
+          echo + $SWANDIR
+          export PATH=${SWANDIR}:${ADCIRCDIR}:${PATH}
+          echo
+          echo "* don't forget to save profile"
           export PS1="asgs (${_ASGSH_CURRENT_PROFILE}*)> "
-          echo "don't forget to save profile"
       else
           echo "ADCIRC build, '$__ADCIRC_BUILD' does not exist. Use 'list adcirc' to see a which ADCIRCs are available to load"
       fi

--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -468,7 +468,7 @@ export _ASGSH_PID=\$\$
 
 # denotes which environmental variables we care about when saving a profile - includes variables that
 # are meaningful to ASGS Shell, but not set in asgs-brew.pl
-export _ASGS_EXPORTED_VARS="$_asgs_exported_vars _ASGS_EXPORTED_VARS WORK SCRATCH EDITOR PROPERTIESFILE INSTANCENAME RUNDIR SYSLOG ASGS_CONFIG ADCIRC_MAKE_CMD SWAN_MAKE_CMD ADCIRC_BINS SWAN_BINS"
+export _ASGS_EXPORTED_VARS="$_asgs_exported_vars _ASGS_EXPORTED_VARS WORK SCRATCH EDITOR PROPERTIESFILE INSTANCENAME RUNDIR SYSLOG ASGS_CONFIG ADCIRC_MAKE_CMD SWAN_UTIL_BINS_MAKE_CMD ADCSWAN_MAKE_CMD ADCIRC_BINS SWAN_UTIL_BINS ADCSWAN_BINS"
 $env_summary
 
 # export opts for processing in $rcfile


### PR DESCRIPTION
Issue #391 - Adding support for building v55 of ADCIRC and
updating support for the "load adcirc" command (which updates
$PATH, etc based on where the binaries are expected to be upon
successful compilation)

NOTE: This commit doesn't represent an exhaustive validation process
for use of v55 in ASGS operationally. But this commit is a
precondition for such a validation.