### PR TITLE
added partial grib downloading

### DIFF
--- a/NAMtoOWIRamp.pl
+++ b/NAMtoOWIRamp.pl
@@ -139,9 +139,13 @@ unless ( open(APPLOGFILE,">>NAMtoOWIRamp.pl.log") ) {
    exit 1;
 }
 &stderrMessage( "INFO", "Started processing NAM data." );
+#
+# check to make sure that outDir and dataDir have slashes at the
+# end (this script assumes they do)
+if ( substr($outDir,-1,1) ne "/" ) { $outDir .= "/"; }
+if ( substr($dataDir,-1,1) ne "/" ) { $dataDir .= "/"; }
 &stderrMessage( "INFO", "Started processing point file." );
 $geoHeader = &processPtFile($ptFile);
-
 # load NAM data
 if ( ( $namFormat eq "grib2" ) || ( $namFormat eq "grb2" ) || ( $namFormat eq "grb" ) ) {
     &stderrMessage( "INFO", "Processing file(s)." );

--- a/NAMtoOWIRamp.pl
+++ b/NAMtoOWIRamp.pl
@@ -48,7 +48,7 @@
 # perl ~/asgs/2014stable/NAMtoOWIRamp.pl --ptFile ~/asgs/2014stable/input/ptFile_hsofs.txt --namFormat grib2 --namType nowcast --awipGridNumber 218 --dataDir ./ --outDir ./ --velocityMultiplier 1.0 --scriptDir ~/asgs/2014stable --applyRamp yes --rampDistance 1.0
 #
 # Example of partial grib2 download of NAM reanalysis :
-# day=1 ; while [[ $day -lt 32 ]]; do daystring=`printf %02d $day`; echo $daystring ; TARGETURL=https://www.ncei.noaa.gov/data/north-american-mesoscale-model/access/historical/analysis/201907/201907${daystring} ; for cycle in 00 06 12 18 ; do  $METSCRIPTDIR/get_inv.pl $TARGETURL/namanl_218_201907${daystring}_${cycle}00_000.inv | grep -E "(PRMSL|UGRD:10 m above ground|VGRD:10 m above ground)" | $METSCRIPTDIR/get_grib.pl $TARGETURL/namanl_218_201907${daystring}_${cycle}00_000.grb2 namanl_218_201907${daystring}_${cycle}00_000.grb2 ; done ; day=`expr $day + 1`; done 
+# day=1 ; while [[ $day -lt 32 ]]; do daystring=`printf %02d $day`; echo $daystring ; TARGETURL=https://www.ncei.noaa.gov/data/north-american-mesoscale-model/access/historical/analysis/201907/201907${daystring} ; for cycle in 00 06 12 18 ; do  $METSCRIPTDIR/get_inv.pl $TARGETURL/namanl_218_201907${daystring}_${cycle}00_000.inv | grep -E "(PRMSL|UGRD:10 m above ground|VGRD:10 m above ground)" | $METSCRIPTDIR/get_grib.pl $TARGETURL/namanl_218_201907${daystring}_${cycle}00_000.grb2 namanl_218_201907${daystring}_${cycle}00_000.grb2 ; done ; day=`expr $day + 1`; done
 #
 #
 ######################################################
@@ -117,7 +117,7 @@ GetOptions(
 #
 # create a hash of properties from run.properties
 our %properties;
-# open properties file 
+# open properties file
 unless (open(RUNPROP,"<run.properties")) {
    stderrMessage("ERROR","Failed to open run.properties: $!.");
    #die;
@@ -135,7 +135,7 @@ unless (open(RUNPROP,"<run.properties")) {
 #
 # open an application log file for get_nam.pl
 unless ( open(APPLOGFILE,">>NAMtoOWIRamp.pl.log") ) {
-   stderrMessage("ERROR","Could not open 'NAMtoOWIRamp.pl.log' for appending: $!.");        
+   stderrMessage("ERROR","Could not open 'NAMtoOWIRamp.pl.log' for appending: $!.");
    exit 1;
 }
 &stderrMessage( "INFO", "Started processing NAM data." );
@@ -715,10 +715,10 @@ sub getGrib2 {
             die "$file not found.\n" if ( !-f $file );
             my $com = "$scriptDir/wgrib2 $file -match \"UGRD:10\" -inv /dev/null -text -";
             @rawU = `$com`;
-            die "rawU is empty, com=$com\n" unless (@rawU);            
+            die "rawU is empty, com=$com\n" unless (@rawU);
             $com  = "$scriptDir/wgrib2 $file -match \"VGRD:10\" -inv /dev/null -text -";
             @rawV = `$com`;
-            die "rawV is empty, com=$com\n" unless (@rawV);            
+            die "rawV is empty, com=$com\n" unless (@rawV);
             $com  = "$scriptDir/wgrib2 $file -match \"PRMSL\" -inv /dev/null -text -";
             @rawP = `$com`;
             die "rawP is empty, com=$com\n" unless (@rawP);
@@ -856,7 +856,7 @@ sub stderrMessage () {
 }
 
 #
-# write a log message to a log file dedicated to this script (typically debug messages)        
+# write a log message to a log file dedicated to this script (typically debug messages)
 sub appMessage () {
    my $level = shift;
    my $message = shift;

--- a/NAMtoOWIRamp.pl
+++ b/NAMtoOWIRamp.pl
@@ -3,7 +3,7 @@
 # NAMtoOWIRamp.pl
 #--------------------------------------------------------------------------
 # Copyright(C) 2019 Brett Estrade
-# Copyright(C) 2011--2019 Jason Fleming
+# Copyright(C) 2011--2021 Jason Fleming
 # Copyright(C) 2010--2011 Eve-Marie Devaliere
 #
 # This file is part of the ADCIRC Surge Guidance System (ASGS).

--- a/NAMtoOWIRamp.pl
+++ b/NAMtoOWIRamp.pl
@@ -84,6 +84,8 @@ my ( $OWItimeRef, $startTime, $endTime, $timeStep, $mainHeader, @OWItime, $recor
 my $applyRamp    = "no";                                    # whether or not to apply a spatial extrapolation ramp
 my $rampDistance = 1.0;                                     # distance in lambert coords to ramp vals to zero
 my ( @ugrd_store_files, @vgrd_store_files, @atmp_store_files );
+our $scenario = "nullscenario";
+
 
 # @ugrd holds the lambert gridded u wind velocity data, across all time steps
 # @vgrd holds the lambert gridded v wind velocity data, across all time steps
@@ -118,16 +120,18 @@ our %properties;
 # open properties file 
 unless (open(RUNPROP,"<run.properties")) {
    stderrMessage("ERROR","Failed to open run.properties: $!.");
-   die;
+   #die;
+} else {
+    while (<RUNPROP>) {
+        my @fields = split ':',$_, 2 ;
+        # strip leading and trailing spaces and tabs
+        $fields[0] =~ s/^\s|\s+$//g ;
+        $fields[1] =~ s/^\s|\s+$//g ;
+        $properties{$fields[0]} = $fields[1];
+    }
+    close(RUNPROP);
+    $scenario = $properties{"scenario"};
 }
-while (<RUNPROP>) {
-   my @fields = split ':',$_, 2 ;
-   # strip leading and trailing spaces and tabs
-   $fields[0] =~ s/^\s|\s+$//g ;
-   $fields[1] =~ s/^\s|\s+$//g ;
-   $properties{$fields[0]} = $fields[1];
-}
-close(RUNPROP);
 #
 # open an application log file for get_nam.pl
 unless ( open(APPLOGFILE,">>NAMtoOWIRamp.pl.log") ) {
@@ -858,6 +862,6 @@ sub appMessage () {
    my $year = 1900 + $yearOffset;
    my $hms = sprintf("%02d:%02d:%02d",$hour, $minute, $second);
    my $theTime = "[$year-$months[$month]-$dayOfMonth-T$hms]";
-   my $scenario = $properties{"scenario"};
+
    printf APPLOGFILE "$theTime $level: $scenario: get_nam.pl: $message\n";
 }

--- a/NAMtoOWIRamp.pl
+++ b/NAMtoOWIRamp.pl
@@ -711,14 +711,13 @@ sub getGrib2 {
             die "$file not found.\n" if ( !-f $file );
             my $com = "$scriptDir/wgrib2 $file -match \"UGRD:10\" -inv /dev/null -text -";
             @rawU = `$com`;
+            die "rawU is empty, com=$com\n" unless (@rawU);            
             $com  = "$scriptDir/wgrib2 $file -match \"VGRD:10\" -inv /dev/null -text -";
             @rawV = `$com`;
+            die "rawV is empty, com=$com\n" unless (@rawV);            
             $com  = "$scriptDir/wgrib2 $file -match \"PRMSL\" -inv /dev/null -text -";
             @rawP = `$com`;
-            die "rawU is empty, com=$com\n" unless (@rawU);
-            die "rawV is empty, com=$com\n" unless (@rawV);
             die "rawP is empty, com=$com\n" unless (@rawP);
-
         }
         if ( $namFormat eq "grb" ) {
             #

--- a/archive/enstorm_pedir_removal.sh
+++ b/archive/enstorm_pedir_removal.sh
@@ -3,7 +3,7 @@
 # esnstorm_pedir_removal.sh: Removes the PE* subdirectories that were
 # created by adcprep for use in a parallel adcirc simulation.  
 #----------------------------------------------------------------
-# Copyright(C) 2017--2019 Jason Fleming
+# Copyright(C) 2017--2021 Jason Fleming
 #
 # This file is part of the ADCIRC Surge Guidance System (ASGS).
 #

--- a/archive/enstorm_pedir_removal.sh
+++ b/archive/enstorm_pedir_removal.sh
@@ -115,6 +115,15 @@ wait
 # archive the subdomain fort.16 log files
 tar cjf fort.16.tar.bz2 ./PE*/fort.16 1> tar.log 2> errmsg && cat tar.log | tee -a $LOGFILE >> $SCENARIOLOG || warn "cycle $CYCLE: $SCENARIO: $THIS: Could not create a tar archive of subdomain fort.16 files: `cat errmsg`." $LOGFILE
 #
+# archive grib2 files if any
+if ls *grib* >&/dev/null ; then
+   scenarioMessage "$THIS: Archiving grib files." $LOGFILE 
+   tar czf grib.tar.gz *grib* 1> tar.log 2> errmsg && cat tar.log | tee -a $LOGFILE >> $SCENARIOLOG || warn "cycle $CYCLE: $SCENARIO: $THIS: Could not create a tar archive of grib2 files: `cat errmsg`." $LOGFILE
+   rm -rf *grib* 2>> $SYSLOG
+else
+   scenarioMessage "$THIS: There are no grib files to archive." $LOGFILE   
+fi
+#
 #
 # pull in platform-specific value for the command used to remove directories
 # (some platforms have a special command that is nicer for their filesystem)

--- a/archive/enstorm_pedir_removal.sh
+++ b/archive/enstorm_pedir_removal.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #----------------------------------------------------------------
 # esnstorm_pedir_removal.sh: Removes the PE* subdirectories that were
-# created by adcprep for use in a parallel adcirc simulation.  
+# created by adcprep for use in a parallel adcirc simulation.
 #----------------------------------------------------------------
 # Copyright(C) 2017--2021 Jason Fleming
 #
@@ -20,8 +20,8 @@
 # You should have received a copy of the GNU General Public License
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #----------------------------------------------------------------
-# This script gets all the information it needs from the 
-# run.properties file instead of using command line arguments. 
+# This script gets all the information it needs from the
+# run.properties file instead of using command line arguments.
 #----------------------------------------------------------------
 THIS=archive/enstorm_pedir_removal.sh
 # this assumes this script is executed in the dirctory that is to be archived
@@ -69,7 +69,7 @@ if [[ $WAVES = on ]]; then
    # preserve the swan log file and swan Errfile (if any) so we can see it later
    # FIXME: the name of the asgs_swan.prt file is provided in swaninit but it
    # is hardcoded here as asgs_swan.prt
-   for file in ./PE0000/asgs_swan.prt ./PE0000/Errfile ; do 
+   for file in ./PE0000/asgs_swan.prt ./PE0000/Errfile ; do
       if [[ -e $file ]]; then
          scenarioMessage "$THIS: Preserving SWAN $file file." $LOGFILE
          cp $file . > errmsg 2>&1 || warn "cycle $CYCLE: $SCENARIO: $THIS: Could not copy '$file' to $PWD: `cat errmsg`." $LOGFILE
@@ -87,14 +87,14 @@ if [[ $WAVES = on ]]; then
          (
             scenarioMessage "$THIS: Creating tar archive of subdomain $file files."
             tar cf ${file}.tar ./PE*/$file 1> tar.log 2> errmsg && cat tar.log | tee -a $LOGFILE >> $SCENARIOLOG || warn "cycle $CYCLE: $SCENARIO: $THIS: Could not create a tar archive of subdomain $file files: `cat errmsg`." $LOGFILE
-            if [[ $SWANHSCOMPRESSION = yes ]]; then 
+            if [[ $SWANHSCOMPRESSION = yes ]]; then
                bzip2 ${file}.tar > errmsg 2>&1 || warn "cycle $CYCLE: $SCENARIO: $THIS: Could not bzip2 '${file}.tar': `cat errmsg`." $LOGFILE
             fi
             scenarioMessage "$THIS: Finished creating tar archive of subdomain $file files." $LOGFILE
          ) &
          (
-            scenarioMessage "$THIS: Creating fulldomain SWAN hotstart file from subdomain $file files." $LOGFILE        
-            ${SWANDIR}/$hSWANExe <<EndInput | tee $LOGFILE >> $SCENARIOLOG 2>&1 
+            scenarioMessage "$THIS: Creating fulldomain SWAN hotstart file from subdomain $file files." $LOGFILE
+            ${SWANDIR}/$hSWANExe <<EndInput | tee $LOGFILE >> $SCENARIOLOG 2>&1
 1
 $file
 F
@@ -108,20 +108,20 @@ EndInput
    done
 fi
 #
-# allow all backgrounded processes to finish before going on to 
+# allow all backgrounded processes to finish before going on to
 # delete subdomain directories
-wait 
+wait
 #
 # archive the subdomain fort.16 log files
 tar cjf fort.16.tar.bz2 ./PE*/fort.16 1> tar.log 2> errmsg && cat tar.log | tee -a $LOGFILE >> $SCENARIOLOG || warn "cycle $CYCLE: $SCENARIO: $THIS: Could not create a tar archive of subdomain fort.16 files: `cat errmsg`." $LOGFILE
 #
 # archive grib2 files if any
 if ls *grib* >&/dev/null ; then
-   scenarioMessage "$THIS: Archiving grib files." $LOGFILE 
+   scenarioMessage "$THIS: Archiving grib files." $LOGFILE
    tar czf grib.tar.gz *grib* 1> tar.log 2> errmsg && cat tar.log | tee -a $LOGFILE >> $SCENARIOLOG || warn "cycle $CYCLE: $SCENARIO: $THIS: Could not create a tar archive of grib2 files: `cat errmsg`." $LOGFILE
    rm -rf *grib* 2>> $SYSLOG
 else
-   scenarioMessage "$THIS: There are no grib files to archive." $LOGFILE   
+   scenarioMessage "$THIS: There are no grib files to archive." $LOGFILE
 fi
 #
 #
@@ -133,14 +133,14 @@ env_dispatch ${HPCENVSHORT}
 THIS=archive/enstorm_pedir_removal.sh
 # now delete the subdomain directories
 rm errmsg ; touch errmsg
-for dir in `ls -d PE*`; do 
-   $REMOVALCMD $dir 2>> errmsg | tee -a $LOGFILE >> $SCENARIOLOG 
+for dir in `ls -d PE*`; do
+   $REMOVALCMD $dir 2>> errmsg | tee -a $LOGFILE >> $SCENARIOLOG
 done
-if [[ -s errmsg  ]]; then 
+if [[ -s errmsg  ]]; then
    warn "cycle $CYCLE: $SCENARIO: $THIS: Could not remove PE subdirectories: `cat errmsg`." $LOGFILE
 fi
 for file in metis_graph.txt partmesh.txt fort.80 ; do
-   if [[ -e $file ]]; then 
+   if [[ -e $file ]]; then
       $REMOVALCMD partmesh.txt
    fi
 done

--- a/config/2021/asgs_config_Shinnecock_nam_jgf.sh
+++ b/config/2021/asgs_config_Shinnecock_nam_jgf.sh
@@ -24,7 +24,7 @@
 # You should have received a copy of the GNU General Public License along with
 # the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------
-# The defaults for parameters that can be reset in this config file 
+# The defaults for parameters that can be reset in this config file
 # are preset in the following scripts:
 # {SCRIPTDIR/platforms.sh               # also contains Operator-specific info
 # {SCRIPTDIR/config/config_defaults.sh
@@ -80,7 +80,7 @@ HOTORCOLD=coldstart      # "hotstart" or "coldstart"
 # location on lonestar5 ______________________________________________
 LASTSUBDIR=null
 
-# Scenario package 
+# Scenario package
 
 #PERCENT=default
 SCENARIOPACKAGESIZE=2 # number of storms in the ensemble

--- a/config/2021/asgs_config_Shinnecock_nam_jgf.sh
+++ b/config/2021/asgs_config_Shinnecock_nam_jgf.sh
@@ -75,7 +75,7 @@ TDS=( )
 
 # Initial state (overridden by STATEFILE after ASGS gets going)
 
-COLDSTARTDATE=2021021500
+COLDSTARTDATE=2021030700
 HOTORCOLD=coldstart      # "hotstart" or "coldstart"
 # location on lonestar5 ______________________________________________
 LASTSUBDIR=null

--- a/get_nam.pl
+++ b/get_nam.pl
@@ -4,38 +4,38 @@
 # for ASGS nowcasts and forecasts
 #--------------------------------------------------------------
 # Copyright(C) 2010--2021 Jason Fleming
-# 
+#
 # This file is part of the ADCIRC Surge Guidance System (ASGS).
-# 
+#
 # The ASGS is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # ASGS is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #
 #--------------------------------------------------------------
-# If nowcast data is requested, the script will grab the nowcast 
+# If nowcast data is requested, the script will grab the nowcast
 # data corresponding to the current ADCIRC time, and then grab all
-# successive nowcast data, if any. 
+# successive nowcast data, if any.
 #
-# If forecast data is requested, the script will grab the 
+# If forecast data is requested, the script will grab the
 # forecast data corresponding to the current ADCIRC time.
 #--------------------------------------------------------------
 # ref: http://www.cpc.ncep.noaa.gov/products/wesley/fast_downloading_grib.html
 #--------------------------------------------------------------
 # sample line to test this script :
 #
-# perl get_nam.pl --statefile /scratch/Shinnecock_nam_jgf.state 
-#                 --rundir /scratch/asgs2827 
-#                 --backsite ftp.ncep.noaa.gov 
-#                 --backdir /pub/data/nccf/com/nam/prod 
+# perl get_nam.pl --statefile /scratch/Shinnecock_nam_jgf.state
+#                 --rundir /scratch/asgs2827
+#                 --backsite ftp.ncep.noaa.gov
+#                 --backdir /pub/data/nccf/com/nam/prod
 #                 --enstorm nowcast
 #                 --csdate 2021021500
 #                 --forecastlength 84
@@ -43,7 +43,7 @@
 #                 --altnamdirs /projects/ncfs/data/asgs5463,/projects/ncfs/data/asgs14174
 #                 --archivedruns /scratch
 #                 --forecastcycle 00,06,12,18
-#                 --scriptdir /work/asgs  
+#                 --scriptdir /work/asgs
 #
 # (the $statefile variable does not seem to be used anywhere in
 # this script, this has been recorded as issue)
@@ -63,20 +63,20 @@ our $backdir;  # dir on ncep ftp site
 our $enstorm;  # hindcast, nowcast, or forecast
 my $csdate;   # UTC date and hour (YYYYMMDDHH) of ADCIRC cold start
 my $hstime;   # hotstart time, i.e., time since ADCIRC cold start (in seconds)
-my @altnamdirs; # alternate directories to look in for NAM data 
+my @altnamdirs; # alternate directories to look in for NAM data
 our $archivedruns; # path to previously conducted and archived files
 our @forecastcycle; # nam cycles to run a forecast (not just nowcast)
 my $scriptDir;  # directory where the wgrib2 executable is found
 #
 my $date;     # date (UTC) corresponding to current ADCIRC time
 my $hour;     # hour (UTC) corresponding to current ADCIRC time
-my @targetDirs; # directories to download NAM data from 
-our $forecastLength = 84; # keeps retrying until it has enough forecast files 
+my @targetDirs; # directories to download NAM data from
+our $forecastLength = 84; # keeps retrying until it has enough forecast files
                     # to go for the requested time period
 our $max_retries = 20; # max number of times to attempt download of forecast file
-our $num_retries = 0;      
+our $num_retries = 0;
 our $had_enough = 0;
-my @nowcasts_downloaded;  # list of nowcast files that were 
+my @nowcasts_downloaded;  # list of nowcast files that were
                           # successfully downloaded
 our @grib_fields = ( "PRMSL","UGRD:10 m above ground","VGRD:10 m above ground" );
 
@@ -97,7 +97,7 @@ GetOptions(
           );
 #
 # open an application log file for get_nam.pl
-unless ( open(APPLOGFILE,">>$rundir/get_nam.pl.log") ) { 
+unless ( open(APPLOGFILE,">>$rundir/get_nam.pl.log") ) {
    stderrMessage("ERROR","Could not open '$rundir/get_nam.pl.log' for appending: $!.");
    exit 1;
 }
@@ -105,7 +105,7 @@ unless ( open(APPLOGFILE,">>$rundir/get_nam.pl.log") ) {
 &appMessage("DEBUG","Connecting to $backsite:$backdir");
 our $dl = 0;   # true if we were able to download the file(s) successfully
 # open ftp connection
-our $ftp = Net::FTP->new($backsite, Debug => 0, Passive => 1); 
+our $ftp = Net::FTP->new($backsite, Debug => 0, Passive => 1);
 unless ( defined $ftp ) {
    stderrMessage("ERROR","ftp: Cannot connect to $backsite: $@");
    printf STDOUT $dl;
@@ -127,9 +127,9 @@ unless ( $hcDirSuccess ) {
    printf STDOUT $dl;
    exit 1;
 }
-# if this is not a nowcast, jump to the sub to get the 
+# if this is not a nowcast, jump to the sub to get the
 # forecast data for this cycle
-if ( defined $enstorm ) { 
+if ( defined $enstorm ) {
    unless ( $enstorm eq "nowcast" ) {
       @forecastcycle = split(/,/,join(',',@forecastcycle));
       &getForecastData();
@@ -137,17 +137,17 @@ if ( defined $enstorm ) {
    }
 }
 #
-# everything below is designed to determine if there is 
-# new nowcast data, and if so, to download it to bring the 
+# everything below is designed to determine if there is
+# new nowcast data, and if so, to download it to bring the
 # simulation state up to date with the latest
 #
 # if alternate (local) directories for NAM data were supplied, then remove the
 # commas from these directories
-if ( @altnamdirs ) { 
+if ( @altnamdirs ) {
    @altnamdirs = split(/,/,join(',',@altnamdirs));
 }
 #
-# Add directory where the ASGS is currently running to the list of 
+# Add directory where the ASGS is currently running to the list of
 # alternate NAM directories so that it can pick up grib2 files that
 # have been downloaded during previous cycles in the same ASGS instance
 # and are needed for the current cycle but are no longer available
@@ -157,7 +157,7 @@ push(@altnamdirs,$rundir);
 #
 # determine date and hour corresponding to current ADCIRC time
 # first (i.e., time of the most recent hotstart file);
-# extract the date/time components 
+# extract the date/time components
 $csdate =~ /(\d\d\d\d)(\d\d)(\d\d)(\d\d)/;
 my $cy = $1;
 my $cm = $2;
@@ -167,7 +167,7 @@ my ($ny, $nm, $nd, $nh, $nmin, $ns); # current ADCIRC time
 if ( defined $hstime && $hstime != 0 ) {
    # now add the hotstart seconds
    ($ny,$nm,$nd,$nh,$nmin,$ns) =
-      Date::Calc::Add_Delta_DHMS($cy,$cm,$cd,$ch,0,0,0,0,0,$hstime);   
+      Date::Calc::Add_Delta_DHMS($cy,$cm,$cd,$ch,0,0,0,0,0,$hstime);
 } else {
    # the hotstart time was not provided, or it was provided and is equal to 0
    # therefore the current ADCIRC time is the cold start time, t=0
@@ -190,8 +190,8 @@ $hour = sprintf("%02d",$nh);
 # to see if there is new data available on the site
 # (later than the current adcirc hotstart time)
 my @ncepDirs = $ftp->ls(); # gets all the current data dirs, incl. nam dirs
-my @namDirs; 
-foreach my $dir (@ncepDirs) { 
+my @namDirs;
+foreach my $dir (@ncepDirs) {
    if ( $dir =~ /nam.\d+/ ) { # filter out non-nam dirs
       push(@namDirs,$dir);
    }
@@ -204,8 +204,8 @@ my @targetDirs;
 foreach my $dir (@sortedNamDirs) {
    #stderrMessage("DEBUG","Found the directory '$dir' on the NCEP ftp site.");
    $dir =~ /nam.(\d+)/;
-   if ( $1 < $date ) { 
-      next; 
+   if ( $1 < $date ) {
+      next;
    } else {
       push(@targetDirs,$dir);
    }
@@ -213,9 +213,9 @@ foreach my $dir (@sortedNamDirs) {
 #
 # determine the most recent date/hour ... this is the latest nam cycle time
 $targetDirs[-1] =~ /nam.(\d+)/;
-my $cycledate = $1; 
+my $cycledate = $1;
 &appMessage("DEBUG","The cycledate is '$cycledate'.");
-if ( $cycledate < $date ) { 
+if ( $cycledate < $date ) {
    stderrMessage("ERROR","The cycledate is '$cycledate' but the ADCIRC hotstart date is '$date'; therefore an error has occurred. get_nam.pl is halting this attempted download.");
    printf STDOUT $dl;
    exit;
@@ -228,15 +228,15 @@ unless ( $hcDirSuccess ) {
    exit;
 }
 my $cyclehour;
-#my @allFiles = $ftp->ls(); 
+#my @allFiles = $ftp->ls();
 my @allFiles = grep /awip1200.tm00/, $ftp->ls();
 if (!@allFiles){
    #die "no awip1200 files yet in $targetDirs[-1]\n";
    stderrMessage("ERROR","No awip1200.tm00 files yet in $targetDirs[-1].");
 }
 
-foreach my $file (@allFiles) { 
-   if ( $file =~ /nam.t(\d+)z.awip1200.tm00.grib2/ ) { 
+foreach my $file (@allFiles) {
+   if ( $file =~ /nam.t(\d+)z.awip1200.tm00.grib2/ ) {
       $cyclehour = $1;
 #      stderrMessage("DEBUG","The cyclehour is '$cyclehour'.");
    }
@@ -245,7 +245,7 @@ my $cycletime;
 
 unless (defined $cyclehour ) {
    stderrMessage("WARNING","Could not download the list of NAM files from NCEP.");
-   exit; 
+   exit;
 } else {
    $cycletime = $cycledate . $cyclehour;
 }
@@ -259,7 +259,7 @@ if ( $cycletime <= ($date.$hour) ) {
    exit;
 }
 #
-# if we made it to here, then there must be some new files on the 
+# if we made it to here, then there must be some new files on the
 # NAM ftp site for us to run
 $hcDirSuccess = $ftp->cdup();
 unless ( $hcDirSuccess ) {
@@ -269,20 +269,20 @@ unless ( $hcDirSuccess ) {
    exit;
 }
 # create the local directores for this cycle if needed
-unless ( -e $cycletime ) { 
+unless ( -e $cycletime ) {
    unless ( mkdir($cycletime,0777) ) {
       stderrMessage("ERROR","Could not make directory '$cycletime': $!.");
       die;
    }
 }
 # create the nowcast and forecast directory for this cycle if needed
-unless ( -e $cycletime."/nowcast" ) { 
+unless ( -e $cycletime."/nowcast" ) {
    unless ( mkdir($cycletime."/nowcast",0777) ) {
       stderrMessage("ERROR","Could not make directory '$cycletime/nowcast': $!.");
       die;
    }
 }
-unless ( -e $cycletime."/$enstorm" ) { 
+unless ( -e $cycletime."/$enstorm" ) {
    unless ( mkdir($cycletime."/$enstorm",0777) ) {
       stderrMessage("ERROR","Could not make directory '$cycletime/$enstorm': $!.");
       die;
@@ -291,7 +291,7 @@ unless ( -e $cycletime."/$enstorm" ) {
 #
 # NOWCAST
 my $localDir;    # directory where we are saving these files
-my @targetFiles; #  
+my @targetFiles; #
 #
 # loop over target directories, grabbing all files relevant to a nowcast
 foreach my $dir (@targetDirs) {
@@ -304,42 +304,42 @@ foreach my $dir (@targetDirs) {
       exit;
    }
    # form list of the files we want
-   # for the nowcast files, we need to create at least one deeper 
+   # for the nowcast files, we need to create at least one deeper
    # directory to hold the data for the NAMtoOWI.pl -- the nowcast file
    # names do not indictate the date, and we may end up having to get
-   # multiple nowcasts and stringing them together ... these nowcasts 
+   # multiple nowcasts and stringing them together ... these nowcasts
    # may span more than one day -- the prefix "erl." is arbitrary I think
    # but NAMtoOWI.pl is hardcoded to look for it
    $dir =~ /nam.(\d+)/;
    my $dirDate = $1;
    $localDir = $cycletime."/nowcast/erl.".substr($dirDate,2);
-   unless ( -e $localDir ) { 
+   unless ( -e $localDir ) {
       unless ( mkdir($localDir,0777) ) {
          stderrMessage("ERROR","Could not make the directory '$localDir': $!");
          die;
       }
    }
    #
-   # get any nowcast files in this directory that are later than 
+   # get any nowcast files in this directory that are later than
    # the current adcirc time
    my @nowcastHours = qw/00 06 12 18/;
    # remove hours from the list if we are not interested in them
    foreach my $nchour (@nowcastHours) {
       if ( $dirDate == $date ) {
-         if ( $nchour < $hour ) { 
-            next; # skip any that are before the current adcirc time 
+         if ( $nchour < $hour ) {
+            next; # skip any that are before the current adcirc time
          }
-      } 
+      }
       if ( $dirDate == $cycledate ) {
          if ( $nchour > $cyclehour ) {
             next; # skip any that are after the most recent file we know of
          }
       }
       my $hourString = sprintf("%02d",$nchour);
-      my $fbase = "nam.t".$hourString."z.awip1200.tm00"; 
+      my $fbase = "nam.t".$hourString."z.awip1200.tm00";
       my $f = $fbase . ".grib2";
-      my $idxfile = $f . ".idx";  
-   
+      my $idxfile = $f . ".idx";
+
       #my $success = $ftp->get($f,$localDir."/".$f);
       my $err = &partialGribDownload($dirDate, $f, $idxfile, $localDir);
       unless ( $err == 0 ) {
@@ -360,8 +360,8 @@ foreach my $dir (@targetDirs) {
       exit;
    }
 }
-# check to see if we got all the nowcast files that are needed to span the 
-# time from the current hot start file to the latest files from 
+# check to see if we got all the nowcast files that are needed to span the
+# time from the current hot start file to the latest files from
 # the NCEP site. If not, and the NCEP site no longer has files that are
 # needed, then check the alternate directories.
 my $date_needed = $date;
@@ -371,10 +371,10 @@ while ($datetime_needed <= $cycletime) {
    my $already_haveit = 0;
    # look through the list of downloaded files to see if we already have it
    foreach my $downloaded (@nowcasts_downloaded) {
-      if ( $downloaded == $datetime_needed ) { 
+      if ( $downloaded == $datetime_needed ) {
          #stderrMessage("DEBUG","Already downloaded nowcast data for '$datetime_needed'.");
          $already_haveit = 1;
-      } 
+      }
    }
    unless ( $already_haveit == 1 ) {
       # don't have it, look in alternate directories for it
@@ -383,7 +383,7 @@ while ($datetime_needed <= $cycletime) {
          # loop through all the alternative directories
          foreach my $andir (@altnamdirs) {
             #stderrMessage("DEBUG","Checking '$andir'.");
-            my @subdirs = glob("$andir/??????????"); 
+            my @subdirs = glob("$andir/??????????");
             foreach my $subdir (@subdirs) {
                my $alt_location = $subdir."/nowcast/erl.".substr($date_needed,2)."/nam.t".$hour_needed."z.awip1200.tm00.grib2";
                #stderrMessage("DEBUG","Looking for '$alt_location'.");
@@ -417,26 +417,26 @@ while ($datetime_needed <= $cycletime) {
             }
          }
       }
-      if ( $already_haveit == 0 ) { 
+      if ( $already_haveit == 0 ) {
          stderrMessage("WARNING","Still missing the nowcast data for '$datetime_needed'.");
       }
-   }   
+   }
    # now add six hours to determine the next datetime for which we need nowcast
    # data
    $datetime_needed =~ /(\d\d\d\d)(\d\d)(\d\d)(\d\d)/;
    my $yn = $1;
    my $mn = $2;
    my $dn = $3;
-   my $hn = $4;  
+   my $hn = $4;
    my ($ty, $tm, $td, $th, $tmin, $ts); # targeted nowcast time
    # now add 6 hours
    ($ty,$tm,$td,$th,$tmin,$ts) =
-      Date::Calc::Add_Delta_DHMS($yn,$mn,$dn,$hn,0,0,0,6,0,0);   
+      Date::Calc::Add_Delta_DHMS($yn,$mn,$dn,$hn,0,0,0,6,0,0);
    # form the date and hour of the next nowcast data needed
    $date_needed = sprintf("%4d%02d%02d",$ty ,$tm, $td);
    $hour_needed = sprintf("%02d",$th);
    $datetime_needed = $date_needed.$hour_needed;
-}   
+}
 # if we found at least two files, we assume have enough for the next advisory
 if ( $dl >= 2 ) {
    printf STDOUT $cycletime;
@@ -453,12 +453,12 @@ if ( $dl >= 2 ) {
 sub getForecastData() {
    my @targetFiles="";
    # write a properties file to document when the forecast starts and ends
-   unless ( open(FP,">$rundir/forecast.properties") ) { 
+   unless ( open(FP,">$rundir/forecast.properties") ) {
       stderrMessage("ERROR","Could not open '$rundir/forecast.properties' for writing: $!.");
       exit 1;
    }
    # FIXME: this should come from the run.properties file
-   unless ( open(CYCLENUM,"<$rundir/currentCycle") ) { 
+   unless ( open(CYCLENUM,"<$rundir/currentCycle") ) {
       stderrMessage("ERROR","Could not open '$rundir/currentCycle' for reading: $!.");
       exit 1;
    }
@@ -467,7 +467,7 @@ sub getForecastData() {
    stderrMessage("DEBUG","The cycle time for the forecast is '$cycletime'.");
    close(CYCLENUM);
    printf FP "forecastValidStart : $cycletime" . "0000\n";
-   my $localDir = $cycletime."/$enstorm"; 
+   my $localDir = $cycletime."/$enstorm";
    my $cycledate = substr($cycletime,0,8);
    my $cyclehour = substr($cycletime,-2,2);
    $cycledate =~ /(\d\d\d\d)(\d\d)(\d\d)/;
@@ -476,11 +476,11 @@ sub getForecastData() {
    my $cdd = $3;
    #
    # Check to see if the cycle hour matches one that we are supposed to
-   # run a forecast for. If so, write a file called "runme" in the 
-   # forecast directory. 
+   # run a forecast for. If so, write a file called "runme" in the
+   # forecast directory.
    #
-   # If not, check to see if an earlier cycle should have run, but 
-   # failed, and the failure was not made up in a later run. If so, 
+   # If not, check to see if an earlier cycle should have run, but
+   # failed, and the failure was not made up in a later run. If so,
    # write the file called "runme" in the forecast directory.
    #
    # This will require us to calculate the cycle date and hour of the
@@ -501,11 +501,11 @@ sub getForecastData() {
          last;
       }
    }
-   # we may still want to run the forecast to make up for an earlier 
+   # we may still want to run the forecast to make up for an earlier
    # forecast that failed or was otherwise missed (24 hour lookback)
    if ( $runme == 0 && $noforecast == 0 ) {
       my $earlier_success = 0; # 1 if an earlier run succeeded
-      for ( my $i=-6; $i>=-24; $i-=6 ) { 
+      for ( my $i=-6; $i>=-24; $i-=6 ) {
          # determine date/time of previous cycle
 
          my ($pcy, $pcm, $pcd, $pch, $pcmin, $pcs); # previous cycle time
@@ -526,14 +526,14 @@ sub getForecastData() {
                last;
             }
          }
-         # since the ASGS will move failed ensemble directories out of 
-         # their parent cycle directory, the presence of the 
+         # since the ASGS will move failed ensemble directories out of
+         # their parent cycle directory, the presence of the
          # padcswan.namforecast.run.finish or padcirc.namforecast.run.finish
          # files indicates that it was successful
          #
          # If the prior one is present, and was not scheduled, then
-         # we'll assume it was a make-up run; in this case no need to 
-         # force this one. If it is present, and was scheduled, then no need 
+         # we'll assume it was a make-up run; in this case no need to
+         # force this one. If it is present, and was scheduled, then no need
          # for any make up run.
          #
          # When looking for the previous runs, check the current run directory
@@ -543,7 +543,7 @@ sub getForecastData() {
          push(@prev_dirs,$archivedruns);
          foreach my $dir (@prev_dirs) {
             if ( -e "$dir/$previous_cycle/$enstorm/padcswan.$enstorm.run.finish" || -e "$dir/$previous_cycle/$enstorm/padcirc.$enstorm.run.finish" ) {
-               $earlier_success = 1; 
+               $earlier_success = 1;
                stderrMessage("DEBUG","The previous cycle completed successfully and was found at '$dir/$previous_cycle'.");
                last;
             }
@@ -552,7 +552,7 @@ sub getForecastData() {
             stderrMessage("DEBUG","The previous cycle ran. No need for a make-up run.");
             last;
          } else {
-            # ok the prior cycle did not run ... if it was supposed to 
+            # ok the prior cycle did not run ... if it was supposed to
             # then force the current forecast to run
             if ( $was_scheduled == 1 ) {
                $rationale = "The previous cycle '$previous_cycle' did not successfully run a forecast, although it was scheduled. Forcing the current forecast '$cycletime' to run as a make-up run.";
@@ -566,13 +566,13 @@ sub getForecastData() {
       }
    }
    if ( $runme == 1 ) {
-      unless (open(RUNME,">$localDir/runme") ) { 
+      unless (open(RUNME,">$localDir/runme") ) {
          stderrMessage("ERROR","Could not open '$localDir/runme' for writing: $!.");
          exit 1;
       }
       printf RUNME $rationale;
       close(RUNME);
-   } 
+   }
    #
    # in any case, whether we are actually going to run the forecast or not,
    # we always want to download the files
@@ -584,14 +584,14 @@ sub getForecastData() {
       printf STDOUT $dl;
       exit;
    }
-   # forecast files are the list of files to retrieve 
+   # forecast files are the list of files to retrieve
    for (my $i=0; $i<=$forecastLength; $i+=3 ) {
       my $hourString = sprintf("%02d",$cyclehour);
       my $f = "nam.t".$hourString."z.awip12".sprintf("%02d",$i).".tm00.grib2";
       # sometimes an error occurs in Net::FTP causing this script to bomb out;
       # the asgs will retry, but we don't want it to re-download stuff that it
       # already has
-      if ( -e $localDir."/".$f ) { 
+      if ( -e $localDir."/".$f ) {
          # perform a smoke test on the file we found to check that it is
          # not corrupted (not a definitive test but better than nothing)
          unless ( `$scriptDir/wgrib2 $localDir/$f -match PRMSL -inv - -text /dev/null` =~ /PRMSL/ ) {
@@ -613,18 +613,18 @@ sub getForecastData() {
             stderrMessage("INFO","ftp: Get '$f' failed: " . $ftp->message);
             $num_retries++;
             #stderrMessage("DEBUG","num_retries is $num_retries");
-            sleep 60; 
+            sleep 60;
          } else {
             $dl++;
             $success = 1;
-            stderrMessage("INFO","Downloaded in $num_retries attempt(s)."); 
+            stderrMessage("INFO","Downloaded in $num_retries attempt(s).");
          }
       }
       if ( $num_retries >= $max_retries ) {
          $had_enough = 1;
          stderrMessage("INFO","Retried download more than $max_retries times. Giving up on downloading $f.");
-         last;  # if we tried 10 times and couldn't get it, the files are 
-                # probably not there at all, so don't spend time trying to 
+         last;  # if we tried 10 times and couldn't get it, the files are
+                # probably not there at all, so don't spend time trying to
                 # get the rest of them
       }
    }
@@ -643,8 +643,8 @@ sub getForecastData() {
    my $cs = 0;
    my ($ey,$em,$ed,$eh,$emin,$es) =
          Date::Calc::Add_Delta_DHMS($cdy,$cdm,$cdd,$cyclehour,$cmin,$cs,0,$dl*3,0,0);
-                        #  yyyy mm  dd  hh  
-   my $end_date = sprintf("%04d%02d%02d%02d",$ey,$em,$ed,$eh); 
+                        #  yyyy mm  dd  hh
+   my $end_date = sprintf("%04d%02d%02d%02d",$ey,$em,$ed,$eh);
    printf FP "forecastValidEnd : $end_date" . "0000\n";
    close(FP);
 }
@@ -659,29 +659,29 @@ sub partialGribDownload () {
    #--------------------------------------------------------
    #    G R I B   I N V E N T O R Y  A N D   R A N G E S
    #--------------------------------------------------------
-   # FIXME: undo this hardcode for downloading files with curl using 
-   # https://nomads rather than $backsite 
+   # FIXME: undo this hardcode for downloading files with curl using
+   # https://nomads rather than $backsite
    my $idx = "https://nomads.ncep.noaa.gov$backdir/nam.$dirDate/$idxfile";
    # jgfdebug: save a local copy of the inventory file
-   stderrMessage("DEBUG","Downloading '$idx' with the command 'curl -f -s $idx -o $localDir/$idxfile'.");      
-   my $err=system("curl -f -s $idx -o $localDir/$idxfile");  
-   if ( $err != 0 ) {                                   
+   stderrMessage("DEBUG","Downloading '$idx' with the command 'curl -f -s $idx -o $localDir/$idxfile'.");
+   my $err=system("curl -f -s $idx -o $localDir/$idxfile");
+   if ( $err != 0 ) {
       stderrMessage("INFO","curl: Get '$idx' failed.");
       unlink("$localDir/$idxfile");
-      return $err;     
-   }                                                        
+      return $err;
+   }
    # download directly into list
    #stderrMessage("INFO","Downloading '$idx' with the command 'curl -f -s $idx'.");
    #my @gribInventoryLines = `curl -f -s $idx`; # the grib inventory file from the ftp site
-   my @rangeLines;    # inventory with computed ranges 
+   my @rangeLines;    # inventory with computed ranges
    my $last = 0;      # number of immediately preceding lines with same starting byte index
-   my $lastnum = -1;  # starting byte range of previous line (or lines if there are repeats) 
+   my $lastnum = -1;  # starting byte range of previous line (or lines if there are repeats)
    my @old_lines;     # contiguous lines in inventory with same starting byte
    my $has_range = 0; # set to 1 if the inventory already has a range field
    #
    # open index file for this time period
    stderrMessage("INFO","Parsing '$idx' to determine byte ranges of U, V, and P.");
-   unless ( open(GRIBINVENTORY,"<$localDir/$idxfile") ) { 
+   unless ( open(GRIBINVENTORY,"<$localDir/$idxfile") ) {
       stderrMessage("ERROR","Could not open '$localDir/$idxfile' for appending: $!.");
       return 1;
    }
@@ -694,9 +694,9 @@ sub partialGribDownload () {
          $has_range = 1;
          push(@rangeLines,"$_\n");
       } else {
-         # grib1/2 inventory, 
-         #    c o m p u t e   r a n g e   f i e l d 
-         # inventory line format without range field e.g.: 
+         # grib1/2 inventory,
+         #    c o m p u t e   r a n g e   f i e l d
+         # inventory line format without range field e.g.:
          # 1:0:d=2021030106:PRMSL:mean sea level:anl:
          # 2:233889:d=2021030106:PRES:1 hybrid level:anl:
          # 3:476054:d=2021030106:RWMR:1 hybrid level:anl:
@@ -713,7 +713,7 @@ sub partialGribDownload () {
             }
             # now add these old lines to the list of lines with our newly computed ranges
             @rangeLines = (@rangeLines,@old_lines);
-            @old_lines = (); 
+            @old_lines = ();
             $last = 1;
          }  else {
             $last++;
@@ -727,24 +727,24 @@ sub partialGribDownload () {
       foreach my $ol (@old_lines) {
          $ol = "$ol:range=$lastnum\n";
       }
-      @rangeLines = (@rangeLines,@old_lines);         
+      @rangeLines = (@rangeLines,@old_lines);
    }
    #   r a n g e   f i e l d s   h a v e   n o w   b e e n   c o m p u t e d   o r   p r o v i d e d
-   # 
+   #
    # download and concatenate grib2 byte ranges
    # jgfdebug
    #foreach my $li (@rangeLines) {
    #   print $li;
    #}
    # now iterate through them and collect the relevant byte ranges
-   my @ranges;      # byte ranges to download 
+   my @ranges;      # byte ranges to download
    foreach my $li (@rangeLines) {
       my $match = 0;
       # check to see if the line matches one of the fields of interest
       foreach my $gf (@grib_fields) {
          if ( $li =~ /$gf/ ) {
             #print "$li matches $gf\n";
-            # want to download this field 
+            # want to download this field
             chomp($li);
             $li =~ /:range=([0-9]*)-([0-9]*)/;
             my $newrange = $1 . "-" . $2;
@@ -763,7 +763,7 @@ sub partialGribDownload () {
       stderrMessage("INFO","Download complete.");
       return 0;
       #stderrMessage("DEBUG","Now have data for $dirDate$hourString.");
-   } else {               
+   } else {
       stderrMessage("INFO","curl: Get '$f' failed.");
       unlink("$localDir/$f");
       return 1;

--- a/util/input/meteorology/get_inv_debug.pl
+++ b/util/input/meteorology/get_inv_debug.pl
@@ -1,0 +1,167 @@
+#!/usr/bin/env perl
+$curl="curl";
+
+# get_inv.pl            wesley ebisuzaki
+# v0.9  1/2005
+#
+# gets a wgrib inventory from the net
+# adds cURL compatible "range" field (byte address of grib record)
+#
+# requires:
+#   curl:   http://curl.haxx.se open source MIT/X derivate license
+#   perl:   open source
+#
+# configuration:
+#   line 1:  #!{location of perl} -w
+#   line 2:  curl="{location of curl executable}";
+#
+# v0.9 1st version
+# v0.9.3 2/2005
+# v0.9.4 5/2006 grib2 support
+# v0.9.5 7/2006 grib2 support - no need for -range option in inventory
+# v0.9.6 1/2009 someone actually used the -range option in the inventory, remove error message
+# v0.9.7 4/2017 allow URLs that start with https:
+#
+$version="get_inv.pl v0.9.7 4/2017 wesley ebisuzaki\n";
+$file='';
+foreach $_ (@ARGV) {
+  SWITCH: {
+    /^-v$|^--version$/ && do { print STDERR $version; exit 8; };
+    /^ftp:|^http:|^https:/ && do {
+	 if ($file eq '') { $file = $_; last SWITCH; }
+	 else {
+	   print STDERR "error: multiple URLs found\n";
+	   exit 8;
+	 }
+      };
+    /^-h$|^--help$/ && do {
+        print STDERR "$0: gets wgrib inventory from net, adds range field\n";
+        print STDERR "   usage: $0 URL-of-wgrib-inventory\n";
+        print STDERR "   ex: $0 http://nomad3.ncep.noaa.gov/pub/gfs/rotating/gblav.t00z.pgrbf12.inv\n\n";
+        print STDERR "This program is part of a package to select GRIB records (messages)\n";
+        print STDERR "to download.  By selecting specific records, the download times can\n";
+        print STDERR "be significantly reduced.  This program uses cURL and supports grib\n";
+        print STDERR "data on http: (most) and ftp: servers that include wgrib inventories.\n";
+        print STDERR "ref: http://www.cpc.ncep.noaa.gov/products/wesley/fast_downloading_grib.html\n";
+        exit 8;
+      };
+    print STDERR "error: unknown parameter: $_\n";
+    exit 8;
+  }
+}
+
+if ($file eq '') {
+  print STDERR $version;
+  print STDERR "\n$0: gets wgrib inventory from net, adds range field\n";
+  print STDERR "   usage: $0 URL-of-wgrib-inventory\n";
+  exit 8;
+}
+
+open (In, "$curl -f -s $file |");
+
+$last=0;
+$lastnum = -1;
+$has_range = 0;
+while (<In>) {
+  if (/:range=/) {
+#    grib2 inventory has range field
+     $has_range = 1;
+     print $_;
+  }
+  else {
+#    grib1/2 inventory, figure range field
+     chomp;
+     ($f1,$num,$rest) = split(/:/,$_,3);
+
+#    check for missing file
+     if (! defined($num) || "$num" eq "") {
+        sleep(5);
+        print STDERR "ERROR: Bad URL or not wgrib inventory: $file\n";
+        sleep(3);
+        exit 7;
+     }
+
+     if ($lastnum != $num && $last != 0) {
+        $n = $num - 1;
+        for ($i = 0; $i < $last; $i++) {
+            print "$old_lines[$i]:range=$lastnum-$n\n";
+        }
+	      $last = 1;
+        $old_lines[0] = $_;
+     } else {
+        $old_lines[$last++] = $_;
+     }
+   	$lastnum = $num;
+  }
+}
+
+
+$firstCall = 1;
+$repeated = 0;
+$lastStartRange = -1;
+$has_range = 0;
+while (<In>) {
+  if (/:range=/) {
+#    grib2 inventory has range field
+     # just pass the stdin to the stdout
+     $has_range = 1;
+     print $_;
+  }
+  else {
+#    grib1/2 inventory, figure range field
+     # e.g.: 
+     # 1:0:d=2021030106:PRMSL:mean sea level:anl:
+     # 2:233889:d=2021030106:PRES:1 hybrid level:anl:
+     # 3:476054:d=2021030106:RWMR:1 hybrid level:anl:
+     chomp;
+     ($f1,$startRange,$rest) = split(/:/,$_,3);
+
+#    check for missing file
+     if (! defined($startRange) || "$startRange" eq "") {
+        sleep(5);
+        print STDERR "ERROR: Bad URL or not wgrib inventory: $file\n";
+        sleep(3);
+        exit 7;
+     }
+     # if the byte index for the start of the data has not 
+     # changed from the previous line, and this is not the first
+     # trip through the loop
+     if ($lastStartRange != $startRange && $firstCall != 1) {
+        $lastEndRange = $startRange - 1;
+        for ($i = 0; $i < $repeated; $i++) {
+            #print "$_\n"; # jgfdebug
+            print "$old_lines[$i]:range=$lastStartRange-$lastEndRange\n";
+        }
+        $lastStartRange = $startRange;
+	    $repeated = 1;
+        $old_lines[0] = $_;
+     }
+     else {
+        # byte index same as last line, just record stdin
+        $old_lines[$repeated++] = $_;
+	    $lastStartRange = $startRange;   
+     }
+  }
+}
+
+# finished dumping stdin to stdout for grib2 inventories that already have the range field in them
+if ($has_range == 1) { exit 0; }
+
+$f1="";
+$rest="";
+if ($repeated != 0) {
+    for ($i = 0; $i < $repeated; $i++) {
+        print "$old_lines[$i]:range=$lastStartRange\n";
+    }
+}
+else {
+  sleep(5);
+  print STDERR "missing wgrib inventory\n";
+  sleep(3);
+  if (! -t STDIN) {
+#   not a terminal .. sleep longer
+    sleep(60);
+  }
+  exit 6;
+}
+exit 0;

--- a/util/input/meteorology/get_inv_debug.pl
+++ b/util/input/meteorology/get_inv_debug.pl
@@ -91,7 +91,7 @@ while (<In>) {
      } else {
         $old_lines[$last++] = $_;
      }
-   	$lastnum = $num;
+        $lastnum = $num;
   }
 }
 
@@ -109,7 +109,7 @@ while (<In>) {
   }
   else {
 #    grib1/2 inventory, figure range field
-     # e.g.: 
+     # e.g.:
      # 1:0:d=2021030106:PRMSL:mean sea level:anl:
      # 2:233889:d=2021030106:PRES:1 hybrid level:anl:
      # 3:476054:d=2021030106:RWMR:1 hybrid level:anl:
@@ -123,7 +123,7 @@ while (<In>) {
         sleep(3);
         exit 7;
      }
-     # if the byte index for the start of the data has not 
+     # if the byte index for the start of the data has not
      # changed from the previous line, and this is not the first
      # trip through the loop
      if ($lastStartRange != $startRange && $firstCall != 1) {
@@ -139,7 +139,7 @@ while (<In>) {
      else {
         # byte index same as last line, just record stdin
         $old_lines[$repeated++] = $_;
-	    $lastStartRange = $startRange;   
+	    $lastStartRange = $startRange;
      }
   }
 }


### PR DESCRIPTION
Resolves #406 to download only the portion (U, V, P) of the grib2 files that are actually needed to provide meteorological forcing. Reduces the disk space usage from 32MB per forecast file (with 28 forecast files needed per NAM forecast) to ~600kB per file.  